### PR TITLE
build(moccache): backport per-build stats with miss reasons and stable version.h

### DIFF
--- a/.github/actions/cmake-build/action.yml
+++ b/.github/actions/cmake-build/action.yml
@@ -95,4 +95,5 @@ runs:
       shell: bash
       env:
         MOCCACHE_DIR: ${{ github.workspace }}/.cache/moccache
-      run: python3 "${GITHUB_WORKSPACE}/tools/moccache.py" --show-stats
+        BUILD_DIR: ${{ inputs.build-dir }}
+      run: python3 "${GITHUB_WORKSPACE}/tools/moccache.py" --show-stats --build-dir "$BUILD_DIR"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,8 @@ set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
     ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/ccache-launcher"
 )
 
+qgc_add_moccache_stats(${CMAKE_PROJECT_NAME})
+
 include(Sanitizers)
 
 include(Coverage)

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -153,8 +153,37 @@ function(qgc_config_moccache)
     file(WRITE "${_moccache_wrapper}" "${_wrapper}")
     file(CHMOD "${_moccache_wrapper}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
+    # Post-build stats script; no-op unless MOCCACHE_STATS is set in the build environment.
+    set(_moccache_stats "${CMAKE_BINARY_DIR}/moccache-stats")
+    set(_stats "#!/bin/sh\n")
+    string(APPEND _stats "[ -n \"\${MOCCACHE_STATS}\" ] || exit 0\n")
+    string(APPEND _stats "export MOCCACHE_DIR=\"\${MOCCACHE_DIR:-${CMAKE_SOURCE_DIR}/.cache/moccache}\"\n")
+    string(APPEND _stats "export MOCCACHE_BASEDIR=\"\${MOCCACHE_BASEDIR:-${CMAKE_BINARY_DIR}}\"\n")
+    string(APPEND _stats "\"${QGC_MOCCACHE_PYTHON}\" \"${_moccache_py}\" --show-stats --build-dir \"${CMAKE_BINARY_DIR}\" || true\n")
+    file(WRITE "${_moccache_stats}" "${_stats}")
+    file(CHMOD "${_moccache_stats}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
     set(CMAKE_AUTOMOC_EXECUTABLE "${_moccache_wrapper}" PARENT_SCOPE)
+    set_property(GLOBAL PROPERTY QGC_MOCCACHE_STATS_EXECUTABLE "${_moccache_stats}")
     message(STATUS "QGC: Using moccache for AUTOMOC (${_real_moc})")
+endfunction()
+
+# ----------------------------------------------------------------------------
+# qgc_add_moccache_stats
+# Print this build's moccache hit/miss stats after the given target links
+# (when MOCCACHE_STATS is set). Ninja only: per-build scoping needs .ninja_log.
+# ----------------------------------------------------------------------------
+function(qgc_add_moccache_stats target)
+    get_property(_moccache_stats GLOBAL PROPERTY QGC_MOCCACHE_STATS_EXECUTABLE)
+    if(_moccache_stats AND TARGET ${target} AND CMAKE_GENERATOR MATCHES "Ninja")
+        add_custom_command(
+            TARGET ${target}
+            POST_BUILD
+            COMMAND "${_moccache_stats}"
+            COMMENT "moccache stats"
+            VERBATIM
+        )
+    endif()
 endfunction()
 
 # ----------------------------------------------------------------------------

--- a/docs/en/qgc-dev-guide/getting_started/index.md
+++ b/docs/en/qgc-dev-guide/getting_started/index.md
@@ -201,18 +201,28 @@ re-validated by content hash on every use.
 
 Environment variables (set by the launcher, overridable at build time):
 
-| Variable            | Default                  | Purpose                                            |
-| ------------------- | ------------------------ | -------------------------------------------------- |
-| `MOCCACHE_DIR`      | `<repo>/.cache/moccache` | Cache location (persisted by CI, like ccache)      |
-| `MOCCACHE_MAX_SIZE` | `256M`                   | LRU auto-trim threshold (trims after misses)       |
-| `MOCCACHE_DISABLE`  | unset                    | Pass through to real moc (no caching)              |
-| `MOCCACHE_STATS`    | unset                    | Append hit/miss lines to `$MOCCACHE_DIR/stats.log` |
+| Variable            | Default                  | Purpose                                                   |
+| ------------------- | ------------------------ | --------------------------------------------------------- |
+| `MOCCACHE_DIR`      | `<repo>/.cache/moccache` | Cache location (persisted by CI, like ccache)             |
+| `MOCCACHE_MAX_SIZE` | `256M`                   | LRU auto-trim threshold (trims after misses)              |
+| `MOCCACHE_DISABLE`  | unset                    | Pass through to real moc (no caching)                     |
+| `MOCCACHE_STATS`    | unset                    | Log hits/misses; print this build's stats after linking   |
 
 ```sh
-MOCCACHE_STATS=1 just build                             # Log hits/misses during a build
+MOCCACHE_STATS=1 just build                             # This build's hit/miss stats print after linking
+MOCCACHE_BASEDIR=$PWD/build/Debug python3 ./tools/moccache.py --show-stats --build-dir build/Debug --verbose  # Per-miss reasons for the last build
+python3 ./tools/moccache.py --zero-stats                # Reset the stats log
 python3 ./tools/moccache.py --trim --max-size 256M      # Explicitly trim the cache (LRU)
 MOCCACHE_DISABLE=1 just build                           # Bypass the cache for one build
 ```
+
+Each miss is logged with a reason, and the report explains each kind inline, so you can tell
+expected misses from cache problems: `miss-first-seen`, `miss-header-changed`,
+`miss-include-changed` and `miss-predefs-changed` are expected; `miss-cache-evicted` means the
+cache is too small (raise `MOCCACHE_MAX_SIZE`); `miss-args-changed` and
+`miss-output-depth-differs` mean build trees differ in a way that defeats sharing and are worth
+investigating (`--verbose` shows the first differing argument per miss). See the docstring at the
+top of `tools/moccache.py` for the full list.
 
 ## Building QGC Installation Files
 

--- a/src/MAVLink/mavlink-deterministic-mavgen.patch
+++ b/src/MAVLink/mavlink-deterministic-mavgen.patch
@@ -9,3 +9,12 @@
          -m pymavlink.tools.mavgen
          --lang=C
          --wire-protocol=${MAVLINK_VERSION}
+--- a/pymavlink/generator/mavgen_c.py
++++ b/pymavlink/generator/mavgen_c.py
+@@ -24,6 +24,5 @@ def generate_version_h(directory, xml):
+ #ifndef MAVLINK_VERSION_H
+ #define MAVLINK_VERSION_H
+
+-#define MAVLINK_BUILD_DATE "${parse_time}"
+ #define MAVLINK_WIRE_PROTOCOL_VERSION "${wire_protocol_version}"
+ #define MAVLINK_MAX_DIALECT_PAYLOAD_SIZE ${largest_payload}

--- a/tools/moccache.py
+++ b/tools/moccache.py
@@ -12,7 +12,7 @@ or set MOCCACHE_MOC=/path/to/moc and invoke:
 or trim the cache to a size limit (LRU eviction):
     moccache.py --trim [--max-size 256M]
 or report / reset recorded stats (requires MOCCACHE_STATS during the build):
-    moccache.py --show-stats
+    moccache.py --show-stats --build-dir DIR [--verbose]
     moccache.py --zero-stats
 
 Environment:
@@ -26,7 +26,31 @@ Environment:
                       LRU-trimmed opportunistically after misses (at most once
                       per hour). Unset = unlimited.
     MOCCACHE_DISABLE  If set, always pass through to real moc.
-    MOCCACHE_STATS    If set, append hit/miss lines to $MOCCACHE_DIR/stats.log.
+    MOCCACHE_STATS    If set, append "<kind>\t<input>\t<epoch>\t<basedir>\t<detail>"
+                      lines to $MOCCACHE_DIR/stats.log. --show-stats reports
+                      only the ninja build in DIR (entries newer than the
+                      build start derived from DIR/.ninja_log, from this
+                      MOCCACHE_BASEDIR) and then prunes that build dir's older
+                      entries, so the log stays about one build long (other
+                      build dirs' entries are left for their own reports; when
+                      the build start cannot be derived it reports everything).
+                      The log is always capped at _STATS_LOG_MAX_LINES. The
+                      CMake-generated moccache-stats post-build script runs it
+                      after linking.
+
+Stats kinds. Misses carry a reason so legitimate misses can be told apart
+from cache-design problems (a per-input index of recent keys under
+$MOCCACHE_DIR/index makes the comparison possible). --show-stats prints each
+kind's count with the explanation from _KIND_DESCRIPTIONS; in short:
+    expected      miss-first-seen, miss-header-changed, miss-include-changed
+                  (detail = the include), miss-predefs-changed (after a
+                  compiler-flag change), miss-moc-version-changed (Qt upgrade)
+    investigate   miss-args-changed (detail = first differing arg; -I/-D churn
+                  between build trees defeats sharing), miss-output-depth-differs
+    cache size    miss-cache-evicted, miss-history-evicted -> raise MOCCACHE_MAX_SIZE
+    other         miss-uncacheable (moc gave no dep file), miss-cache-unreadable
+                  (entry incomplete or could not be copied out), cache-trimmed
+                  (detail = entries evicted)
 """
 
 from __future__ import annotations
@@ -205,10 +229,11 @@ def _atomic_copy(src: Path, dst: Path) -> None:
 
 
 def _atomic_write(dst: Path, data: str) -> None:
+    """Replace dst with data as UTF-8/LF, independent of the platform locale."""
     dst.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=str(dst.parent), prefix=".moccache-")
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
             f.write(data)
         os.replace(tmp, dst)
     except BaseException:
@@ -219,6 +244,23 @@ def _atomic_write(dst: Path, data: str) -> None:
 
 def _make_escape(path: str) -> str:
     return path.replace(" ", "\\ ")
+
+
+def _append_line(path: Path, line: str) -> None:
+    """Append one line as a single write(2) on an O_APPEND descriptor.
+
+    The OS performs each such write atomically on local filesystems, so
+    concurrent processes cannot interleave or clobber each other's lines;
+    buffered text I/O gives no such guarantee. (Lines over PIPE_BUF, 4 KiB
+    on POSIX, lose it too.)
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_BINARY", 0)
+    fd = os.open(path, flags, 0o600)
+    try:
+        os.write(fd, (line + "\n").encode("utf-8"))
+    finally:
+        os.close(fd)
 
 
 _BASEDIR_TOKEN = "<<MOCCACHE_BASEDIR>>"
@@ -264,14 +306,141 @@ def _write_dep_file(dst: Path, target: str, deps: list[str]) -> None:
     _atomic_write(dst, f"{_make_escape(target)}: \\\n  {body}\n")
 
 
-def _log_stat(cache_dir: Path, what: str, input_file: str) -> None:
+_STAT_FIELD_BREAKERS = str.maketrans({"\t": " ", "\n": " ", "\r": " "})
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}")
+
+
+def _log_stat(cache_dir: Path, what: str, input_file: str, detail: str = "") -> None:
+    """Append a stats line; input_file is a moc input path or "" for non-input events."""
     if not os.environ.get("MOCCACHE_STATS"):
         return
+    basedir = os.environ.get("MOCCACHE_BASEDIR", "")
+    # Free-text fields must not be able to break the tab-separated record.
+    input_file, basedir, detail = (
+        s.translate(_STAT_FIELD_BREAKERS) for s in (input_file, basedir, detail)
+    )
+    with contextlib.suppress(OSError):
+        _append_line(
+            cache_dir / "stats.log",
+            f"{what}\t{input_file}\t{time.time():.3f}\t{basedir}\t{detail}",
+        )
+
+
+# Per-input index of recent cache keys, used only to explain misses.
+_INDEX_MAX_KEYS = 8
+
+# Shown next to each kind in --show-stats so the report is self-explanatory.
+_KIND_DESCRIPTIONS = {
+    "miss-first-seen": "first time this header was moc'd",
+    "miss-header-changed": "the header itself changed",
+    "miss-include-changed": "a header it includes changed",
+    "miss-predefs-changed": "moc_predefs.h changed: compiler flags or SDK differ",
+    "miss-moc-version-changed": "moc version changed",
+    "miss-args-changed": "moc arguments differ: build trees not sharing, investigate",
+    "miss-output-depth-differs": "autogen output dir depth differs between build trees",
+    "miss-cache-evicted": "entry was trimmed from the cache: raise MOCCACHE_MAX_SIZE",
+    "miss-cache-unreadable": "entry exists but is incomplete or could not be copied out",
+    "miss-history-evicted": "all previous entries trimmed, cannot diff: raise MOCCACHE_MAX_SIZE",
+    "miss-uncacheable": "moc produced no dep file, result not cached",
+    "cache-trimmed": "auto-trim ran, detail = entries evicted",
+    "bad-max-size": "MOCCACHE_MAX_SIZE is not a valid size, detail = the value",
+}
+
+
+def _index_path(cache_dir: Path, input_file: str, basedir_prefixes: list[str]) -> Path:
+    ident = hashlib.sha256(
+        _normalize_basedir(os.path.abspath(input_file), basedir_prefixes).encode()
+    ).hexdigest()
+    return cache_dir / "index" / ident[:2] / ident
+
+
+def _index_read(path: Path) -> list[str]:
+    """The newest _INDEX_MAX_KEYS distinct keys, oldest first."""
     try:
-        with (cache_dir / "stats.log").open("a", encoding="utf-8") as f:
-            f.write(f"{what}\t{input_file}\n")
-    except OSError:
-        pass
+        raw = path.read_text(encoding="utf-8").split()
+    except (OSError, UnicodeDecodeError):
+        return []
+    newest_first = list(dict.fromkeys(reversed(raw)))
+    return newest_first[:_INDEX_MAX_KEYS][::-1]
+
+
+# Compact once the append-only file grows well past what _index_read keeps.
+_INDEX_COMPACT_LINES = _INDEX_MAX_KEYS * 8
+
+
+def _index_add(path: Path, mkey: str) -> None:
+    """Record mkey for this input.
+
+    Append-only (see _append_line) so concurrent misses on the same header
+    (parallel builds of sibling trees) never lose each other's keys the way
+    a read-modify-write would. Compaction rewrites rarely enough that its
+    small race window is acceptable for a diagnostics aid.
+    """
+    with contextlib.suppress(OSError):
+        _append_line(path, mkey)
+        if path.stat().st_size > _INDEX_COMPACT_LINES * (len(mkey) + 1):
+            _atomic_write(path, "\n".join(_index_read(path)) + "\n")
+
+
+def _diff_key_parts(old: list[str], new: list[str]) -> tuple[str, str]:
+    """Classify how a previous key differs from the current one.
+
+    Layout is [moc identity, *args, input sha, relpath]; args are compared
+    after the fixed parts so the most legitimate cause wins.
+    """
+    if len(old) < 3 or len(new) < 3:
+        return "miss-args-changed", "key layout changed"
+    if old[0] != new[0]:
+        return "miss-moc-version-changed", f"{old[0]} -> {new[0]}"
+    if old[-2] != new[-2]:
+        return "miss-header-changed", ""
+    if old[-1] != new[-1]:
+        return "miss-output-depth-differs", f"{old[-1]} -> {new[-1]}"
+    old_args, new_args = old[1:-2], new[1:-2]
+    for i, (a, b) in enumerate(zip(old_args, new_args, strict=False)):
+        if a != b:
+            if i > 0 and old_args[i - 1] == "--include":
+                return "miss-predefs-changed", ""
+            return "miss-args-changed", f"{a} -> {b}"
+    if len(old_args) != len(new_args):
+        extra = (
+            new_args[len(old_args) :]
+            if len(new_args) > len(old_args)
+            else old_args[len(new_args) :]
+        )
+        sign = "+" if len(new_args) > len(old_args) else "-"
+        return "miss-args-changed", sign + " ".join(extra)
+    return "miss-args-changed", "identical key parts"  # should not happen: same key would have hit
+
+
+def _explain_key_miss(
+    cache_dir: Path, index: Path, mkey: str, key_parts: list[str]
+) -> tuple[str, str]:
+    """Reason for finding no entry at mkey, using the input's previous keys."""
+    previous = _index_read(index)
+    if not previous:
+        return "miss-first-seen", ""
+    if mkey in previous:
+        return "miss-cache-evicted", ""
+    best: tuple[int, str, str] | None = None
+    for old_key in reversed(previous):
+        try:
+            old_parts = (
+                (cache_dir / old_key[:2] / old_key / "keyinfo")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            )
+        except (OSError, UnicodeDecodeError):
+            continue
+        kind, detail = _diff_key_parts(old_parts, key_parts)
+        ndiff = sum(1 for a, b in zip(old_parts, key_parts, strict=False) if a != b) + abs(
+            len(old_parts) - len(key_parts)
+        )
+        if best is None or ndiff < best[0]:
+            best = (ndiff, kind, detail)
+    if best is None:
+        return "miss-history-evicted", "previous entries evicted"
+    return best[1], best[2]
 
 
 _SIZE_SUFFIXES = {"k": 1024, "m": 1024**2, "g": 1024**3, "t": 1024**4}
@@ -339,7 +508,9 @@ def _maybe_auto_trim(cache_dir: Path) -> None:
     try:
         max_bytes = _parse_size(limit)
     except ValueError:
-        _log_stat(cache_dir, "bad-max-size", limit)  # misconfig breadcrumb; cache stays untrimmed
+        _log_stat(
+            cache_dir, "bad-max-size", "", limit
+        )  # misconfig breadcrumb; cache stays untrimmed
         return
     stamp = cache_dir / "trim.stamp"
     lock = cache_dir / "trim.lock"
@@ -359,7 +530,9 @@ def _maybe_auto_trim(cache_dir: Path) -> None:
                 lock.unlink()
             return
         try:
-            _trim(cache_dir, max_bytes)
+            removed = _trim(cache_dir, max_bytes)
+            if removed:
+                _log_stat(cache_dir, "cache-trimmed", "", str(removed))
             stamp.touch()  # only after a completed trim; a crash must not suppress retries
         finally:
             with contextlib.suppress(OSError):
@@ -405,20 +578,173 @@ def _cache_dir() -> Path:
     return Path(__file__).resolve().parent.parent / ".cache" / "moccache"
 
 
-def _show_stats_main() -> int:
+# Subtracted from the estimated build start so clock/mtime granularity never
+# drops a moc run that happened in the build's first moments.
+_BUILD_START_SLACK_SECONDS = 2.0
+
+# ninja on Windows logs mtimes as FILETIME ticks (100 ns since 1601-01-01)
+# minus its own 12622770400 s rebase (src/disk_interface.cc), which is *not*
+# exactly 400 years; the Unix offset below is that constant minus 1601->1970.
+_NINJA_LOG_MTIME_IS_FILETIME = sys.platform == "win32"
+_NINJA_FILETIME_UNIX_OFFSET = 12_622_770_400 - 11_644_473_600
+
+# A build start further back than this (or in the future) means the log isn't
+# telling us about the current build; report all stats rather than misfilter.
+_BUILD_START_MAX_AGE_SECONDS = 24 * 3600
+_BUILD_START_MAX_FUTURE_SECONDS = 60
+
+# Edges examined for the build start: enough to always include a real compile
+# alongside any restat command that logged a stale output mtime.
+_BUILD_START_EDGES = 32
+
+
+def _ninja_mtime_to_epoch(mtime: int) -> float:
+    if _NINJA_LOG_MTIME_IS_FILETIME:
+        return mtime / 1e7 + _NINJA_FILETIME_UNIX_OFFSET
+    return mtime / 1e9
+
+
+def _build_start(build_dir: Path) -> float | None:
+    """Approximate start of the ninja build running in build_dir, or None.
+
+    .ninja_log records each finished edge as "start_ms end_ms mtime output
+    hash" with the times relative to the build start and mtime absolute, so
+    a recent edge gives start ~= mtime - end. Restat edges whose output was
+    left untouched log a stale mtime that only ever makes that estimate too
+    early, so the max over the last few edges is taken. (.ninja_lock's mtime
+    is unusable: ninja rewrites it as edges complete.)
+    """
+    # Whole-file read is fine: ninja recompacts .ninja_log itself, keeping it
+    # to a few records per edge (well under a few MB even for large trees).
+    try:
+        lines = (
+            (build_dir / ".ninja_log").read_text(encoding="utf-8", errors="replace").splitlines()
+        )
+    except OSError:
+        return None
+    start: float | None = None
+    examined = 0
+    for line in reversed(lines):
+        if examined >= _BUILD_START_EDGES:
+            break
+        fields = line.split("\t")
+        if line.startswith("#") or len(fields) < 4:
+            continue
+        try:
+            end_ms = int(fields[1])
+            mtime = int(fields[2])
+        except ValueError:
+            continue
+        if mtime <= 0:
+            continue
+        examined += 1
+        candidate = _ninja_mtime_to_epoch(mtime) - end_ms / 1000.0
+        if start is None or candidate > start:
+            start = candidate
+    if start is None:
+        return None
+    now = time.time()
+    if start > now + _BUILD_START_MAX_FUTURE_SECONDS or start < now - _BUILD_START_MAX_AGE_SECONDS:
+        return None
+    return start - _BUILD_START_SLACK_SECONDS
+
+
+def _stat_time(fields: list[str]) -> float | None:
+    """Epoch time of a stats line, or None for legacy lines without one."""
+    if len(fields) < 4:
+        return None
+    try:
+        return float(fields[2])
+    except ValueError:
+        return None
+
+
+# Growth cap for stats.log when no build boundary is available to prune at;
+# comfortably more than one full QGC build's worth of moc runs.
+_STATS_LOG_MAX_LINES = 50_000
+
+
+def _show_stats_main(argv: list[str]) -> int:
+    build_dir: Path | None = None
+    verbose = False
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--build-dir":
+            if i + 1 >= len(argv):
+                print("moccache: --build-dir requires a path", file=sys.stderr)
+                return 2
+            build_dir = Path(argv[i + 1])
+            i += 2
+        elif argv[i] == "--verbose":
+            verbose = True
+            i += 1
+        else:
+            print(f"moccache: --show-stats: unknown argument: {argv[i]}", file=sys.stderr)
+            return 2
+    if build_dir is None:
+        print("moccache: --show-stats requires --build-dir", file=sys.stderr)
+        return 2
+
+    since = _build_start(build_dir)
+    scope = "this build"
+    note = ""
+    if since is None:
+        scope = "all recorded"
+        note = f"  (build start unknown: no usable {build_dir / '.ninja_log'}; showing all recorded stats)"
+    basedir = os.environ.get("MOCCACHE_BASEDIR", "") if since is not None else ""
+    basedir = basedir.translate(_STAT_FIELD_BREAKERS)  # match what _log_stat recorded
+
     cache_dir = _cache_dir()
     log = cache_dir / "stats.log"
     counts: dict[str, int] = {}
+    details: list[tuple[str, str, str]] = []  # (kind, input, detail) for non-hit events
+    keep: list[str] = []  # this build's lines from its start onward, plus every other build dir's
     try:
-        for line in log.read_text(encoding="utf-8", errors="replace").splitlines():
-            what = line.split("\t", 1)[0]
-            counts[what] = counts.get(what, 0) + 1
+        with log.open(encoding="utf-8", errors="replace") as f:
+            for raw in f:
+                line = raw.rstrip("\n")
+                fields = line.split("\t")
+                if since is not None:
+                    when = _stat_time(fields)
+                    if when is None:
+                        continue  # legacy line: prune
+                    if basedir and fields[3] != basedir:
+                        # Another build dir's record; a still-running sibling
+                        # build may need it, so only its own report prunes it.
+                        keep.append(line)
+                        continue
+                    if when < since:
+                        continue  # older than this build: prune
+                    keep.append(line)
+                else:
+                    keep.append(line)
+                kind = fields[0]
+                counts[kind] = counts.get(kind, 0) + 1
+                if kind != "hit":
+                    details.append(
+                        (
+                            kind,
+                            fields[1] if len(fields) > 1 else "",
+                            fields[4] if len(fields) > 4 else "",
+                        )
+                    )
     except OSError:
         pass
+    # Only per-build reports are ever wanted, so this build's older entries are
+    # dead weight; drop them to keep the log about one build long. The cap
+    # bounds records left behind by build dirs that never report again. A
+    # concurrent build appending during this rewrite can lose a few lines;
+    # acceptable for a diagnostics aid.
+    if since is not None or len(keep) > _STATS_LOG_MAX_LINES:
+        with contextlib.suppress(OSError):
+            _atomic_write(log, "".join(line + "\n" for line in keep[-_STATS_LOG_MAX_LINES:]))
     hits = counts.pop("hit", 0)
-    misses = counts.pop("miss", 0)
+    # Pre-reason logs used a bare "miss"; fold it in with the miss-* reasons.
+    misses = counts.pop("miss", 0) + sum(n for k, n in counts.items() if k.startswith("miss-"))
     total = hits + misses
-    print(f"moccache stats ({cache_dir}):")
+    print(f"moccache stats ({scope}, {cache_dir}):")
+    if note:
+        print(note)
     if total == 0 and not counts:
         print("  no stats recorded")
         return 0
@@ -426,12 +752,22 @@ def _show_stats_main() -> int:
     print(f"  misses   {misses}")
     if total:
         print(f"  hit rate {100.0 * hits / total:.1f}%")
+    width = max((len(k) for k in counts), default=0)
     for what in sorted(counts):
-        print(f"  {what}  {counts[what]}")
+        why = _KIND_DESCRIPTIONS.get(what)
+        suffix = f"  ({why})" if why else ""
+        print(f"  {what:<{width}}  {counts[what]:>5}{suffix}")
+    if verbose and details:
+        print("details:")
+        for kind, input_file, detail in details:
+            print(f"  {kind}  {input_file}  {detail}".rstrip())
     return 0
 
 
-def _zero_stats_main() -> int:
+def _zero_stats_main(argv: list[str]) -> int:
+    if argv:
+        print(f"moccache: --zero-stats: unknown argument: {argv[0]}", file=sys.stderr)
+        return 2
     with contextlib.suppress(OSError):
         (_cache_dir() / "stats.log").unlink()
     return 0
@@ -441,11 +777,10 @@ def main() -> int:
     argv = sys.argv[1:]
     if argv and argv[0] == "--trim":
         return _trim_main(argv[1:])
-    if argv and argv[0] in ("--show-stats", "--zero-stats"):
-        if len(argv) > 1:
-            print(f"moccache: {argv[0]} takes no arguments: {argv[1]}", file=sys.stderr)
-            return 2
-        return _show_stats_main() if argv[0] == "--show-stats" else _zero_stats_main()
+    if argv and argv[0] == "--show-stats":
+        return _show_stats_main(argv[1:])
+    if argv and argv[0] == "--zero-stats":
+        return _zero_stats_main(argv[1:])
     real_moc = None
     if argv and argv[0] == "--real-moc":
         if len(argv) < 2:
@@ -501,20 +836,27 @@ def main() -> int:
     json_out = Path(str(out_path) + ".json")
 
     # --- Try for a hit ------------------------------------------------------
+    miss_reason: tuple[str, str] | None = None
     if manifest.is_file() and cached_out.is_file() and (not wants_json or cached_json.is_file()):
         hit = True
         manifest_deps: list[str] = []
         try:
-            for line in manifest.read_text().splitlines():
+            for line in manifest.read_text(encoding="utf-8").splitlines():
                 dep, _, dep_hash = line.partition("\t")
+                if not dep or not _SHA256_HEX.fullmatch(dep_hash):
+                    hit = False
+                    miss_reason = ("miss-cache-unreadable", "manifest malformed")
+                    break
                 dep = _denormalize_basedir(dep)
                 p = Path(dep)
                 if not p.is_file() or _sha256_file(p) != dep_hash:
                     hit = False
+                    miss_reason = ("miss-include-changed", dep)
                     break
                 manifest_deps.append(dep)
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             hit = False
+            miss_reason = ("miss-cache-unreadable", "manifest unreadable")
         if hit:
             try:
                 out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -531,9 +873,18 @@ def main() -> int:
                 _log_stat(cache_dir, "hit", input_file)
                 return 0
             except OSError:
-                pass  # fall through to a real run
+                miss_reason = ("miss-cache-unreadable", "")  # fall through to a real run
+    elif mdir.is_dir():
+        miss_reason = ("miss-cache-unreadable", "entry incomplete")
 
     # --- Miss: run real moc with dep-file capture ---------------------------
+    index = _index_path(cache_dir, input_file, basedir_prefixes)
+    if miss_reason is None:
+        # Explaining costs up to _INDEX_MAX_KEYS keyinfo reads; skip when nobody is listening.
+        if os.environ.get("MOCCACHE_STATS"):
+            miss_reason = _explain_key_miss(cache_dir, index, mkey, key_parts)
+        else:
+            miss_reason = ("miss", "")
     tmp_dep = None
     cmd = [str(real_moc), *argv]
     if not wants_dep_file:
@@ -547,9 +898,9 @@ def main() -> int:
 
         dep_src = Path(tmp_dep) if tmp_dep else dep_out
         try:
-            dep_text = dep_src.read_text()
-        except OSError:
-            _log_stat(cache_dir, "miss-nodep", input_file)
+            dep_text = dep_src.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            _log_stat(cache_dir, "miss-uncacheable", input_file)
             return 0  # moc succeeded; just can't cache
 
         # Force-included files are keyed by content, so their (build-dir
@@ -567,9 +918,10 @@ def main() -> int:
                 _atomic_copy(json_out, cached_json)
             _atomic_write(manifest, "\n".join(lines) + "\n")
             _atomic_write(mdir / "keyinfo", "\n".join(key_parts) + "\n")
+            _index_add(index, mkey)
         except OSError:
             pass  # cache write failure must not fail the build
-        _log_stat(cache_dir, "miss", input_file)
+        _log_stat(cache_dir, miss_reason[0], input_file, miss_reason[1])
         _maybe_auto_trim(cache_dir)
         return 0
     finally:

--- a/tools/tests/test_moccache.py
+++ b/tools/tests/test_moccache.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import concurrent.futures
 import os
+import re
 import shutil
 import stat
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -23,6 +25,16 @@ import pytest
 # chmod-based permission tests), matching CI, which only enables moccache on
 # non-Windows runners.
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="moccache is POSIX-only")
+
+# Realistic epoch base so build-start plausibility checks behave as in production.
+_T0 = 1_700_000_000.0
+
+
+@pytest.fixture(autouse=True)
+def _unix_ninja_log_mtimes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests write Unix-ns .ninja_log mtimes regardless of the host platform."""
+    monkeypatch.setattr(moccache, "_NINJA_LOG_MTIME_IS_FILETIME", False)
+
 
 FAKE_MOC = """#!/usr/bin/env python3
 import hashlib
@@ -172,10 +184,19 @@ class Harness:
         return moccache.main()
 
     def stats(self) -> list[str]:
+        """Event kinds in log order, with miss reasons collapsed to "miss"."""
+        return ["miss" if k.startswith("miss-") else k for k, _ in self.stats_detailed()]
+
+    def stats_detailed(self) -> list[tuple[str, str]]:
+        """(kind, detail) pairs in log order; detail is "" when absent."""
         log = self.cache / "stats.log"
         if not log.is_file():
             return []
-        return [line.split("\t")[0] for line in log.read_text().splitlines()]
+        out = []
+        for line in log.read_text(encoding="utf-8").splitlines():
+            fields = line.split("\t")
+            out.append((fields[0], fields[4] if len(fields) > 4 else ""))
+        return out
 
     def moc_runs(self) -> int:
         if not self.moc_log.is_file():
@@ -186,6 +207,25 @@ class Harness:
 @pytest.fixture
 def harness(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Harness:
     return Harness(tmp_path, monkeypatch)
+
+
+def write_ninja_log(build_dir: Path, *edges: tuple[int, int, int]) -> None:
+    """Write a .ninja_log with (start_ms, end_ms, mtime_ns) edges."""
+    build_dir.mkdir(parents=True, exist_ok=True)
+    body = "# ninja log v7\n" + "".join(
+        f"{s}\t{e}\t{m}\tout{i}\t{i:016x}\n" for i, (s, e, m) in enumerate(edges)
+    )
+    (build_dir / ".ninja_log").write_text(body, encoding="utf-8")
+
+
+def show_stats(harness: Harness, *extra: str) -> int:
+    """Run --show-stats against a build that began an hour ago (before every log entry)."""
+    build_dir = harness.root / "bld"
+    write_ninja_log(build_dir, (0, 1000, int((time.time() - 3600) * 1e9)))
+    harness.monkeypatch.setattr(
+        sys, "argv", ["moccache.py", "--show-stats", "--build-dir", str(build_dir), *extra]
+    )
+    return moccache.main()
 
 
 # ---------------------------------------------------------------------------
@@ -217,9 +257,29 @@ class TestBasicCaching:
 
     def test_stats_log_records_input(self, harness: Harness) -> None:
         tree = harness.make_tree("build")
+        harness.monkeypatch.setattr(moccache.time, "time", lambda: 1700000000.1234567)
         harness.run(tree)
-        log = (harness.cache / "stats.log").read_text()
-        assert str(harness.input) in log
+        line = (harness.cache / "stats.log").read_text(encoding="utf-8").splitlines()[0]
+        what, input_file, when, basedir, detail = line.split("\t")
+        assert what == "miss-first-seen"
+        assert input_file == str(harness.input)
+        assert when == "1700000000.123"
+        assert basedir == str(tree.build)
+        assert detail == ""
+
+    def test_stats_log_fields_cannot_break_the_tab_format(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MOCCACHE_STATS", "1")
+        monkeypatch.setenv("MOCCACHE_BASEDIR", "/b\tdir")
+        moccache._log_stat(tmp_path, "miss-args-changed", "/src/we\tird.h", "-DX=a\tb -> -DX=c\nd")
+        line = (tmp_path / "stats.log").read_text(encoding="utf-8")
+        assert line.count("\n") == 1
+        fields = line.rstrip("\n").split("\t")
+        assert len(fields) == 5
+        assert fields[1] == "/src/we ird.h"
+        assert fields[3] == "/b dir"
+        assert fields[4] == "-DX=a b -> -DX=c d"
 
 
 # ---------------------------------------------------------------------------
@@ -712,15 +772,253 @@ class TestTrim:
 
 
 # ---------------------------------------------------------------------------
+# Miss reasons: every miss says what invalidated it so cache-design problems
+# (evictions, arg churn, relpath) can be told apart from legitimate misses.
+# ---------------------------------------------------------------------------
+
+
+class TestKeyIndex:
+    def test_read_returns_newest_distinct_keys_oldest_first(self, tmp_path: Path) -> None:
+        index = tmp_path / "idx"
+        for key in ("k1", "k2", "k1", "k3"):
+            moccache._index_add(index, key)
+        assert moccache._index_read(index) == ["k2", "k1", "k3"]
+
+    def test_read_caps_at_max_keys(self, tmp_path: Path) -> None:
+        index = tmp_path / "idx"
+        for i in range(moccache._INDEX_MAX_KEYS + 3):
+            moccache._index_add(index, f"k{i}")
+        keys = moccache._index_read(index)
+        assert len(keys) == moccache._INDEX_MAX_KEYS
+        assert keys[-1] == f"k{moccache._INDEX_MAX_KEYS + 2}"
+
+    def test_add_appends_without_rewriting(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Concurrent writers must never clobber each other, so a normal add
+        # may only append; rewriting is reserved for compaction.
+        def no_rewrite(*args: object, **kwargs: object) -> None:
+            raise AssertionError("index add must not rewrite the file")
+
+        monkeypatch.setattr(moccache, "_atomic_write", no_rewrite)
+        index = tmp_path / "idx"
+        moccache._index_add(index, "a")
+        moccache._index_add(index, "b")
+        assert index.read_text().split() == ["a", "b"]
+
+    def test_add_is_a_single_append_syscall(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # One write(2) on an O_APPEND fd is what makes concurrent appends safe;
+        # buffered text I/O gives no such guarantee.
+        writes: list[bytes] = []
+        real_write = os.write
+
+        def counting_write(fd: int, data: bytes) -> int:
+            writes.append(bytes(data))
+            return real_write(fd, data)
+
+        monkeypatch.setattr(moccache.os, "write", counting_write)
+        moccache._index_add(tmp_path / "idx", "a" * 64)
+        assert writes == [b"a" * 64 + b"\n"]
+
+    def test_add_compacts_oversized_file(self, tmp_path: Path) -> None:
+        index = tmp_path / "idx"
+        for i in range(moccache._INDEX_COMPACT_LINES + 1):
+            moccache._index_add(index, f"{i:064x}")
+        assert len(index.read_text().split()) <= moccache._INDEX_MAX_KEYS
+        assert moccache._index_read(index)[-1] == f"{moccache._INDEX_COMPACT_LINES:064x}"
+
+    def test_read_missing_file_is_empty(self, tmp_path: Path) -> None:
+        assert moccache._index_read(tmp_path / "nope") == []
+
+
+class TestMissReasons:
+    def test_first_ever_input_is_miss_new(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        assert harness.stats_detailed() == [("miss-first-seen", "")]
+
+    def test_changed_input_is_miss_input(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        harness.input.write_text("class Foo { int v2; };\n")
+        harness.run(tree, out=tree.out_path("b.cpp"))
+        assert harness.stats_detailed()[-1] == ("miss-header-changed", "")
+
+    def test_changed_dependency_is_miss_dep_with_path(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        harness.dep_header.write_text("// dep v2\n")
+        harness.run(tree, out=tree.out_path("b.cpp"))
+        assert harness.stats_detailed()[-1] == ("miss-include-changed", str(harness.dep_header))
+
+    def test_changed_args_is_miss_args_with_diff(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        harness.run(tree, out=tree.out_path("b.cpp"), extra_args=("-DEXTRA=1",))
+        kind, detail = harness.stats_detailed()[-1]
+        assert kind == "miss-args-changed"
+        assert "-DEXTRA=1" in detail
+
+    def test_changed_predefs_is_miss_predefs(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        tree.predefs.write_text(tree.predefs.read_text() + "#define __NEW__ 1\n")
+        harness.run(tree, out=tree.out_path("b.cpp"))
+        assert harness.stats_detailed()[-1] == ("miss-predefs-changed", "")
+
+    def test_changed_moc_is_miss_moc(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        harness.monkeypatch.setenv("FAKEMOC_VERSION", "2.0")
+        harness.run(tree, out=tree.out_path("b.cpp"))
+        assert harness.stats_detailed()[-1][0] == "miss-moc-version-changed"
+
+    def test_different_output_depth_is_miss_relpath(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        deeper = tree.build / "a" / "b" / "c" / "d" / "e"
+        deeper.mkdir(parents=True)
+        harness.run(tree, out=deeper / "moc_Foo.cpp")
+        assert harness.stats_detailed()[-1][0] == "miss-output-depth-differs"
+
+    def test_evicted_entry_is_miss_evicted(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        for shard in harness.cache.glob("??"):
+            shutil.rmtree(shard)
+        harness.run(tree, out=tree.out_path("b.cpp"))
+        assert harness.stats_detailed()[-1] == ("miss-cache-evicted", "")
+
+    def test_unreadable_cached_output_is_not_reported_as_evicted(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        (cached_out,) = harness.cache.glob("??/*/output.cpp")
+        real_copyfile = shutil.copyfile
+
+        def failing_copyfile(src: object, dst: object, *args: object, **kwargs: object) -> object:
+            if Path(str(src)) == cached_out:
+                raise OSError("cached output unreadable")
+            return real_copyfile(src, dst, *args, **kwargs)  # type: ignore[arg-type]
+
+        harness.monkeypatch.setattr(moccache.shutil, "copyfile", failing_copyfile)
+        assert harness.run(tree, out=tree.out_path("b.cpp")) == 0
+        kind, detail = harness.stats_detailed()[-1]
+        assert kind == "miss-cache-unreadable"
+        assert detail == ""
+
+    def test_incomplete_cache_entry_is_not_reported_as_evicted(self, harness: Harness) -> None:
+        # A crash between writing output.cpp and the manifest leaves the entry
+        # dir behind; that is not an eviction and must not point at MAX_SIZE.
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        (cached_out,) = harness.cache.glob("??/*/output.cpp")
+        cached_out.unlink()
+        assert harness.run(tree, out=tree.out_path("b.cpp")) == 0
+        assert harness.stats_detailed()[-1] == ("miss-cache-unreadable", "entry incomplete")
+
+    def test_corrupt_manifest_is_cache_unreadable_not_include_changed(
+        self, harness: Harness
+    ) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        (manifest,) = harness.cache.glob("??/*/manifest")
+        manifest.write_bytes(b"\xff\xfe not utf-8")
+        assert harness.run(tree, out=tree.out_path("b.cpp")) == 0
+        assert harness.stats_detailed()[-1] == ("miss-cache-unreadable", "manifest unreadable")
+
+    def test_malformed_manifest_line_is_cache_unreadable(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        (manifest,) = harness.cache.glob("??/*/manifest")
+        manifest.write_text(f"{harness.dep_header}\n", encoding="utf-8")  # no tab / hash
+        assert harness.run(tree, out=tree.out_path("b.cpp")) == 0
+        assert harness.stats_detailed()[-1] == ("miss-cache-unreadable", "manifest malformed")
+
+    def test_corrupt_index_degrades_to_miss(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        (index,) = harness.cache.glob("index/??/*")
+        index.write_bytes(b"\xff\xfe not utf-8")
+        assert harness.run(tree, out=tree.out_path("b.cpp"), extra_args=("-DEXTRA=1",)) == 0
+        assert harness.stats()[-1] == "miss"
+
+    def test_uncacheable_miss_is_logged_on_fresh_cache(self, harness: Harness) -> None:
+        # Nothing else has created MOCCACHE_DIR yet when moc yields no dep file.
+        real_run = moccache.subprocess.run
+
+        def run_and_drop_dep_file(cmd: list[str], *args: object, **kwargs: object) -> object:
+            result = real_run(cmd, *args, **kwargs)  # type: ignore[arg-type]
+            if "--dep-file-path" in cmd:
+                Path(cmd[cmd.index("--dep-file-path") + 1]).unlink()
+            return result
+
+        harness.monkeypatch.setattr(moccache.subprocess, "run", run_and_drop_dep_file)
+        tree = harness.make_tree("build")
+        assert not harness.cache.exists()
+        assert harness.run(tree) == 0
+        assert harness.stats_detailed() == [("miss-uncacheable", "")]
+
+    def test_miss_reason_not_computed_when_stats_disabled(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        harness.monkeypatch.delenv("MOCCACHE_STATS")
+
+        def explode(*args: object) -> tuple[str, str]:
+            raise AssertionError("_explain_key_miss must not run with stats off")
+
+        harness.monkeypatch.setattr(moccache, "_explain_key_miss", explode)
+        harness.run(tree, out=tree.out_path("b.cpp"), extra_args=("-DEXTRA=1",))
+        # The index still learns the new key so a later stats-on run can diff against it.
+        (index,) = harness.cache.glob("index/??/*")
+        assert len(index.read_text(encoding="utf-8").splitlines()) == 2
+
+    def test_auto_trim_logs_eviction_count(
+        self, harness: Harness, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _fake_entry(harness.cache, "ee" + "0" * 6, 100_000, age=99_999)
+        monkeypatch.setenv("MOCCACHE_MAX_SIZE", "1K")
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        trims = [d for k, d in harness.stats_detailed() if k == "cache-trimmed"]
+        assert trims and int(trims[0]) >= 1
+
+    def test_show_stats_breaks_misses_down_by_reason(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        harness.run(tree, out=tree.out_path("b.cpp"))
+        harness.dep_header.write_text("// dep v2\n")
+        harness.run(tree, out=tree.out_path("c.cpp"))
+        assert show_stats(harness) == 0
+        out = capsys.readouterr().out
+        assert "hits     1" in out
+        assert "misses   2" in out
+        assert "hit rate 33.3%" in out
+        assert re.search(r"miss-first-seen\s+1  \(first time this header was moc'd\)", out)
+        assert re.search(r"miss-include-changed\s+1  \(a header it includes changed\)", out)
+
+    def test_show_stats_verbose_lists_miss_details(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        harness.dep_header.write_text("// dep v2\n")
+        harness.run(tree, out=tree.out_path("b.cpp"))
+        assert show_stats(harness, "--verbose") == 0
+        out = capsys.readouterr().out
+        assert f"miss-include-changed  {harness.input}  {harness.dep_header}" in out
+        assert f"miss-first-seen  {harness.input}" in out
+
+
+# ---------------------------------------------------------------------------
 # Stats CLI (--show-stats / --zero-stats)
 # ---------------------------------------------------------------------------
 
 
 class TestStatsCli:
-    def _show(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sys, "argv", ["moccache.py", "--show-stats"])
-        assert moccache.main() == 0
-
     def test_show_stats_counts_hits_and_misses(
         self, harness: Harness, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -728,7 +1026,7 @@ class TestStatsCli:
         harness.run(tree, out=tree.out_path("a.cpp"))
         harness.run(tree, out=tree.out_path("b.cpp"))
         harness.run(tree, out=tree.out_path("c.cpp"))
-        self._show(harness.monkeypatch)
+        assert show_stats(harness) == 0
         out = capsys.readouterr().out
         assert "hits     2" in out
         assert "misses   1" in out
@@ -737,7 +1035,7 @@ class TestStatsCli:
     def test_show_stats_without_log_reports_zero(
         self, harness: Harness, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        self._show(harness.monkeypatch)
+        assert show_stats(harness) == 0
         out = capsys.readouterr().out
         assert "no stats recorded" in out
 
@@ -761,20 +1059,210 @@ class TestStatsCli:
     ) -> None:
         monkeypatch.setattr(sys, "argv", ["moccache.py", flag, "--frobnicate"])
         assert moccache.main() == 2
-        assert f"{flag} takes no arguments: --frobnicate" in capsys.readouterr().err
+        assert f"{flag}: unknown argument: --frobnicate" in capsys.readouterr().err
+
+    def test_show_stats_requires_build_dir(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["moccache.py", "--show-stats"])
+        assert moccache.main() == 2
+        assert "--show-stats requires --build-dir" in capsys.readouterr().err
+
+    def test_show_stats_build_dir_requires_value(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["moccache.py", "--show-stats", "--build-dir"])
+        assert moccache.main() == 2
+        assert "--build-dir requires a path" in capsys.readouterr().err
+
+    # Mixed log: two builds of /b1 (old at T0+100, current at T0+200), a concurrent
+    # build of /b2, and a legacy line without time/basedir fields.
+    _MIXED_LOG = (
+        f"hit\ta.h\t{_T0 + 100:.1f}\t/b1\n"
+        f"miss\tb.h\t{_T0 + 100:.1f}\t/b1\n"
+        f"hit\tc.h\t{_T0 + 200:.1f}\t/b1\n"
+        f"hit\td.h\t{_T0 + 200:.1f}\t/b1\n"
+        f"miss\te.h\t{_T0 + 200:.1f}\t/b2\n"
+        "hit\tf.h\n"
+    )
+
+    def _write_mixed_log(self, harness: Harness) -> None:
+        harness.cache.mkdir(parents=True, exist_ok=True)
+        (harness.cache / "stats.log").write_text(self._MIXED_LOG, encoding="utf-8")
+
+    def _show_current_build(self, harness: Harness) -> int:
+        """--show-stats at T0+300 for a /b1 build that began at T0+150 (+slack)."""
+        build_dir = harness.root / "bld"
+        start_ns = int((_T0 + 150.0 + moccache._BUILD_START_SLACK_SECONDS + 5.0) * 1e9)
+        write_ninja_log(build_dir, (0, 5000, start_ns))
+        harness.monkeypatch.setattr(moccache.time, "time", lambda: _T0 + 300.0)
+        harness.monkeypatch.setenv("MOCCACHE_BASEDIR", "/b1")
+        harness.monkeypatch.setattr(
+            sys, "argv", ["moccache.py", "--show-stats", "--build-dir", str(build_dir)]
+        )
+        return moccache.main()
+
+    @staticmethod
+    def _expected_start(started_at: float) -> float:
+        return started_at - moccache._BUILD_START_SLACK_SECONDS
+
+    def test_build_start_derived_from_last_ninja_log_edge(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Last edge finished 5 s into the build at absolute T0+155 -> build began at T0+150.
+        monkeypatch.setattr(moccache.time, "time", lambda: _T0 + 300.0)
+        write_ninja_log(
+            tmp_path, (0, 1000, int((_T0 + 100) * 1e9)), (2000, 5000, int((_T0 + 155) * 1e9))
+        )
+        assert moccache._build_start(tmp_path) == pytest.approx(self._expected_start(_T0 + 150))
+
+    def test_build_start_skips_edges_without_output_mtime(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(moccache.time, "time", lambda: _T0 + 300.0)
+        write_ninja_log(tmp_path, (2000, 5000, int((_T0 + 155) * 1e9)), (5000, 6000, 0))
+        assert moccache._build_start(tmp_path) == pytest.approx(self._expected_start(_T0 + 150))
+
+    def test_build_start_ignores_restat_edge_with_stale_output_mtime(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A restat custom command that left its output untouched logs the old
+        # mtime, which would place the build start far in the past on its own.
+        monkeypatch.setattr(moccache.time, "time", lambda: _T0 + 300.0)
+        write_ninja_log(
+            tmp_path,
+            (0, 5000, int((_T0 + 155) * 1e9)),
+            (5000, 6000, int((_T0 - 5000) * 1e9)),
+        )
+        assert moccache._build_start(tmp_path) == pytest.approx(self._expected_start(_T0 + 150))
+
+    def test_build_start_decodes_windows_filetime_mtimes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ninja on Windows logs FILETIME ticks (100 ns since 1601-01-01) minus
+        # its own 12622770400 s rebase constant (src/disk_interface.cc).
+        monkeypatch.setattr(moccache, "_NINJA_LOG_MTIME_IS_FILETIME", True)
+        monkeypatch.setattr(moccache.time, "time", lambda: _T0 + 300.0)
+        filetime_ticks = int((_T0 + 155 + 11_644_473_600) * 10**7)
+        ninja_mtime = filetime_ticks - 12_622_770_400 * 10**7
+        write_ninja_log(tmp_path, (0, 5000, ninja_mtime))
+        assert moccache._build_start(tmp_path) == pytest.approx(self._expected_start(_T0 + 150))
+
+    @pytest.mark.parametrize("started_at", [_T0 + 400.0, _T0 - 2 * 86400.0])
+    def test_build_start_none_when_implausible(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, started_at: float
+    ) -> None:
+        # In the future or days old means the log is not from this build (or
+        # its units are not what we assume): fall back rather than misreport.
+        monkeypatch.setattr(moccache.time, "time", lambda: _T0 + 300.0)
+        write_ninja_log(tmp_path, (0, 5000, int((started_at + 5) * 1e9)))
+        assert moccache._build_start(tmp_path) is None
+
+    def test_build_start_none_without_ninja_log(self, tmp_path: Path) -> None:
+        assert moccache._build_start(tmp_path) is None
+        write_ninja_log(tmp_path)
+        assert moccache._build_start(tmp_path) is None
+
+    def test_show_stats_reports_only_current_build(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._write_mixed_log(harness)
+        assert self._show_current_build(harness) == 0
+        out = capsys.readouterr().out
+        assert "this build" in out
+        assert "hits     2" in out
+        assert "misses   0" in out
+
+    def test_show_stats_prunes_entries_older_than_this_build(self, harness: Harness) -> None:
+        # Older lines are dead weight; the concurrent /b2 build's line is kept
+        # because its own post-build report still needs it.
+        self._write_mixed_log(harness)
+        assert self._show_current_build(harness) == 0
+        remaining = (harness.cache / "stats.log").read_text(encoding="utf-8").splitlines()
+        assert remaining == [
+            f"hit\tc.h\t{_T0 + 200:.1f}\t/b1",
+            f"hit\td.h\t{_T0 + 200:.1f}\t/b1",
+            f"miss\te.h\t{_T0 + 200:.1f}\t/b2",
+        ]
+
+    def test_show_stats_keeps_older_entries_of_other_build_dirs(self, harness: Harness) -> None:
+        # /b2 began before this /b1 build and may still be running; only its
+        # own report may prune its records.
+        harness.cache.mkdir(parents=True, exist_ok=True)
+        (harness.cache / "stats.log").write_text(
+            f"hit\ta.h\t{_T0 + 100:.1f}\t/b2\n"
+            f"hit\tb.h\t{_T0 + 100:.1f}\t/b1\n"
+            f"hit\tc.h\t{_T0 + 200:.1f}\t/b1\n",
+            encoding="utf-8",
+        )
+        assert self._show_current_build(harness) == 0
+        remaining = (harness.cache / "stats.log").read_text(encoding="utf-8").splitlines()
+        assert remaining == [
+            f"hit\ta.h\t{_T0 + 100:.1f}\t/b2",
+            f"hit\tc.h\t{_T0 + 200:.1f}\t/b1",
+        ]
+
+    def test_show_stats_prunes_to_empty_when_build_logged_nothing(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A no-op build still clears the previous build's entries.
+        harness.cache.mkdir(parents=True, exist_ok=True)
+        (harness.cache / "stats.log").write_text(
+            f"hit\ta.h\t{_T0 + 100:.1f}\t/b1\n", encoding="utf-8"
+        )
+        assert self._show_current_build(harness) == 0
+        assert "no stats recorded" in capsys.readouterr().out
+        assert (harness.cache / "stats.log").read_text(encoding="utf-8") == ""
+
+    def test_show_stats_without_ninja_log_falls_back_and_keeps_log(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._write_mixed_log(harness)
+        build_dir = harness.root / "bld"
+        build_dir.mkdir()
+        harness.monkeypatch.setenv("MOCCACHE_BASEDIR", "/b1")
+        harness.monkeypatch.setattr(
+            sys, "argv", ["moccache.py", "--show-stats", "--build-dir", str(build_dir)]
+        )
+        assert moccache.main() == 0
+        out = capsys.readouterr().out
+        assert "build start unknown" in out
+        assert "hits     4" in out
+        assert "misses   2" in out
+        assert (harness.cache / "stats.log").read_text(encoding="utf-8") == self._MIXED_LOG
+
+    def test_show_stats_without_ninja_log_caps_log_growth(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # With no build boundary to prune at, the log must still be bounded.
+        harness.monkeypatch.setattr(moccache, "_STATS_LOG_MAX_LINES", 3)
+        harness.cache.mkdir(parents=True, exist_ok=True)
+        lines = [f"hit\t{i}.h\t{_T0 + i}\t/b1" for i in range(5)]
+        (harness.cache / "stats.log").write_text("".join(f"{s}\n" for s in lines), encoding="utf-8")
+        build_dir = harness.root / "bld"
+        build_dir.mkdir()
+        harness.monkeypatch.setattr(
+            sys, "argv", ["moccache.py", "--show-stats", "--build-dir", str(build_dir)]
+        )
+        assert moccache.main() == 0
+        assert "hits     5" in capsys.readouterr().out
+        remaining = (harness.cache / "stats.log").read_text(encoding="utf-8").splitlines()
+        assert remaining == lines[-3:]
 
     def test_show_stats_with_only_other_events_still_prints_counts(
         self, harness: Harness, capsys: pytest.CaptureFixture[str]
     ) -> None:
         harness.cache.mkdir(parents=True, exist_ok=True)
-        (harness.cache / "stats.log").write_text("bad-max-size\tx\n")
-        self._show(harness.monkeypatch)
+        (harness.cache / "stats.log").write_text(
+            f"bad-max-size\t\t{time.time():.3f}\t\tx\n", encoding="utf-8"
+        )
+        assert show_stats(harness) == 0
         out = capsys.readouterr().out
         assert "no stats recorded" not in out
         assert "hits     0" in out
         assert "misses   0" in out
         assert "hit rate" not in out
-        assert "bad-max-size  1" in out
+        assert re.search(r"bad-max-size\s+1  \(MOCCACHE_MAX_SIZE is not a valid size", out)
 
     def test_zero_then_show_reports_zero(
         self, harness: Harness, capsys: pytest.CaptureFixture[str]
@@ -783,7 +1271,7 @@ class TestStatsCli:
         harness.run(tree)
         harness.monkeypatch.setattr(sys, "argv", ["moccache.py", "--zero-stats"])
         assert moccache.main() == 0
-        self._show(harness.monkeypatch)
+        assert show_stats(harness) == 0
         assert "no stats recorded" in capsys.readouterr().out
 
     def test_auto_trim_on_miss_when_max_size_set(
@@ -793,7 +1281,7 @@ class TestStatsCli:
         monkeypatch.setenv("MOCCACHE_MAX_SIZE", "1K")
         tree = harness.make_tree("build")
         harness.run(tree)
-        assert harness.stats() == ["miss"]
+        assert harness.stats() == ["miss", "cache-trimmed"]
         assert not (harness.cache / "ee" / ("ee" + "0" * 6)).is_dir()
 
     def test_auto_trim_respects_stamp_interval(
@@ -824,7 +1312,10 @@ class TestStatsCli:
         big = _fake_entry(tmp_path, "ee" + "0" * 6, 100_000, age=99_999)
         moccache._maybe_auto_trim(tmp_path)
         assert big.is_dir()  # no trim, but also no crash
-        assert "bad-max-size\tbogus" in (tmp_path / "stats.log").read_text()
+        line = (tmp_path / "stats.log").read_text(encoding="utf-8").splitlines()[0].split("\t")
+        assert line[0] == "bad-max-size"
+        assert line[1] == ""  # not a moc input
+        assert line[4] == "bogus"
 
     def test_stamp_vanishing_mid_check_still_trims(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Backport to Stable_V5.1 of two build-cache improvements from master.

### moccache per-build stats with miss reasons (d6470d45a4)

Brings `tools/moccache.py` up to master: `--show-stats --build-dir DIR [--verbose]` scopes the report to the last ninja build and classifies every miss (`miss-first-seen`, `miss-header-changed`, `miss-include-changed`, `miss-cache-evicted`, `miss-args-changed`, ...), which is what made the `version.h` problem below diagnosable. Includes the test suite (114 passing), the CI `--show-stats --build-dir` step, docs, and the post-build stats print (`MOCCACHE_STATS=1 just build` prints this build's hit/miss report after linking).

Stable's moccache CMake wiring predates `qgc_apply_moccache`, so the POST_BUILD hook is attached via a new `qgc_add_moccache_stats(<target>)` called on the main executable instead of the master shape. The Python >= 3.10 `find_program` validator is not ported. Verified with a fresh Ninja configure: `moccache-stats` script is generated and the POST_BUILD edge is present.

### Stable `version.h` (#15070, master PR #15073)

Extends `src/MAVLink/mavlink-deterministic-mavgen.patch` to drop the unused `MAVLINK_BUILD_DATE` define from the generated `version.h`. Same MAVLink pin as master (`c409cf6`); `git apply --check` verified. `version.h` is now byte-identical between master and stable, so a shared moccache/ccache gets cross-branch hits for the whole `MAVLinkLib.h`-including subtree.

Note: stable's `CPMAddPackage` has no `CUSTOM_CACHE_KEY`, so an existing local CPM mavlink checkout will not be re-patched automatically — delete `$CPM_SOURCE_CACHE/mavlink/<hash>` for stable once after pulling this. CI is unaffected.
