### PR TITLE
fix(Camera): stop zoom slider echoing camera-reported zoom back as a command (Stable_V5.1)

### DIFF
--- a/src/Comms/MockLink/MockLinkCamera.cc
+++ b/src/Comms/MockLink/MockLinkCamera.cc
@@ -350,11 +350,19 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
 
     case MAV_CMD_SET_CAMERA_ZOOM:
         if (cam->capFlags & CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM) {
-             // param2 is an absolute level only for ZOOM_TYPE_RANGE. For step/continuous
-             // zoom it is a direction, which this simple simulation does not model.
-             if (static_cast<int>(request.param1) == ZOOM_TYPE_RANGE) {
+             // param2 is an absolute level for ZOOM_TYPE_RANGE and a direction for
+             // ZOOM_TYPE_STEP. Continuous zoom is not modeled.
+             switch (static_cast<int>(request.param1)) {
+             case ZOOM_TYPE_RANGE:
                  cam->zoomLevel = request.param2;
                  qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "zoom set to" << cam->zoomLevel;
+                 break;
+             case ZOOM_TYPE_STEP:
+                 cam->zoomLevel = std::clamp(cam->zoomLevel + (request.param2 * kZoomStepPercent), kZoomMinPercent, kZoomMaxPercent);
+                 qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "zoom stepped to" << cam->zoomLevel;
+                 break;
+             default:
+                 break;
              }
              // Spec-minimal: CAMERA_SETTINGS is not broadcast after a zoom change.
              // The GCS must re-request it (MAVLink camera protocol v2).

--- a/src/Comms/MockLink/MockLinkCamera.h
+++ b/src/Comms/MockLink/MockLinkCamera.h
@@ -120,6 +120,9 @@ private:
     static constexpr uint8_t  kNumStreams        = 2;    ///< Streams per camera
     static constexpr uint32_t kStorageTotalMiB   = 16384; ///< 16 GiB simulated SD card
     static constexpr uint32_t kStorageFreeMiB    = 8192;  ///< 8 GiB free
+    static constexpr float    kZoomMinPercent    = 0.0f;  ///< CAMERA_SETTINGS.zoomLevel range
+    static constexpr float    kZoomMaxPercent    = 100.0f;
+    static constexpr float    kZoomStepPercent   = 10.0f; ///< Zoom range change per ZOOM_TYPE_STEP
 
     MockLink   *_mockLink = nullptr;
     CameraState _cameras[kNumCameras];           ///< Simulated cameras

--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -49,6 +49,7 @@ Rectangle {
             }
 
             QGCSlider {
+                objectName: "photoVideoControl_zoomSlider"
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: true
                 orientation: Qt.Vertical
@@ -56,7 +57,7 @@ Rectangle {
                 from: 0
                 value: _camera.zoomLevel
                 live: true
-                onValueChanged: _camera.zoomLevel = value
+                onMoved: _camera.zoomLevel = value
             }
         }
 

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -30,6 +30,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4AirframeSetupUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/AppCloseWarningUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/AppCloseWarningUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewCameraZoomUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewCameraZoomUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewProximityRadarUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewProximityRadarUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/NTRIPSettingsUITest.cc
@@ -58,6 +60,7 @@ add_qgc_test(APMSensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 
 add_qgc_test(APMFreshFlashUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(PX4AirframeSetupUITest LABELS Integration NoSanitizer StockUI TIMEOUT 120)
 add_qgc_test(AppCloseWarningUITest LABELS Integration NoSanitizer TIMEOUT 120)
+add_qgc_test(FlyViewCameraZoomUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(FlyViewProximityRadarUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(NTRIPSettingsUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(OnboardLogUITest LABELS Integration NoSanitizer TIMEOUT 180)

--- a/test/QmlUITests/FlyViewCameraZoomUITest.cc
+++ b/test/QmlUITests/FlyViewCameraZoomUITest.cc
@@ -1,0 +1,75 @@
+#include "FlyViewCameraZoomUITest.h"
+
+#include <QtQuick/QQuickItem>
+#include <QtTest/QTest>
+
+#include "MavlinkCameraControlInterface.h"
+#include "MockLink.h"
+#include "QGCCameraManager.h"
+#include "Vehicle.h"
+
+UT_REGISTER_TEST(FlyViewCameraZoomUITest, TestLabel::Integration)
+
+void FlyViewCameraZoomUITest::_testZoomSliderTracksCameraWithoutEcho()
+{
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(MockConfiguration::OptionEnableCamera); },
+        [this](QPointer<MockLink> mockLink, Vehicle* vehicle) {
+            QGCCameraManager* const cameraManager = vehicle->cameraManager();
+            QVERIFY(cameraManager);
+
+            auto findCamera = [cameraManager]() -> MavlinkCameraControlInterface* {
+                for (int i = 0; i < cameraManager->cameras()->count(); i++) {
+                    auto* const cam = qobject_cast<MavlinkCameraControlInterface*>(cameraManager->cameras()->get(i));
+                    if (cam && (cam->compID() == MAV_COMP_ID_CAMERA)) {
+                        return cam;
+                    }
+                }
+                return nullptr;
+            };
+            MavlinkCameraControlInterface* camera = nullptr;
+            QVERIFY_TRUE_WAIT((camera = findCamera()) != nullptr, TestTimeout::longMs());
+            QVERIFY(camera->hasZoom());
+            QVERIFY_TRUE_WAIT(qFuzzyCompare(camera->zoomLevel(), 1.0), TestTimeout::longMs());
+
+            // PhotoVideoControl shows the current camera, which is whichever mock camera announced first
+            cameraManager->setCurrentCamera(cameraManager->cameras()->indexOf(camera));
+            QCOMPARE(cameraManager->currentCameraInstance(), camera);
+
+            const QString sliderName = QStringLiteral("photoVideoControl_zoomSlider");
+            QVERIFY2(findVisibleItem(_rootItem, sliderName, TestTimeout::mediumMs()),
+                     "Zoom slider never became visible");
+            QVERIFY(verifyProperty(sliderName, "value", 1.0, QStringLiteral("initial zoom")));
+
+            auto zoomCommandCount = [&mockLink] {
+                return mockLink->receivedMavCommandCount(MAV_CMD_SET_CAMERA_ZOOM, MAV_COMP_ID_CAMERA);
+            };
+            const int baseline = zoomCommandCount();
+
+            // Joystick-style step zoom: the camera moves to a level QGC did not choose, and
+            // QGC learns about it via the CAMERA_SETTINGS refresh that follows the ack.
+            camera->stepZoom(1);
+            QVERIFY_TRUE_WAIT(zoomCommandCount() >= baseline + 1, TestTimeout::mediumMs());
+            QVERIFY_TRUE_WAIT(camera->zoomLevel() > 1.0, TestTimeout::mediumMs());
+            const qreal steppedLevel = camera->zoomLevel();
+            QVERIFY(verifyProperty(sliderName, "value", steppedLevel, QStringLiteral("stepped zoom")));
+
+            // The slider following the reported level must not send it back to the camera.
+            QVERIFY2(
+                !QTest::qWaitFor([&] { return zoomCommandCount() > baseline + 1; }, TestTimeout::shortMs()),
+                qPrintable(QStringLiteral(
+                               "Slider echoed camera-reported zoom back as SET_CAMERA_ZOOM (%1 commands after step)")
+                               .arg(zoomCommandCount() - baseline)));
+
+            // User interaction with the slider must still command the camera: clicking the
+            // groove moves the handle there and the camera ends up at the slider's value.
+            QVERIFY(clickItemFraction(sliderName, 0.5, 0.5));
+            QVERIFY_TRUE_WAIT(zoomCommandCount() == baseline + 2, TestTimeout::mediumMs());
+            QQuickItem* const slider = findVisibleItem(_rootItem, sliderName);
+            QVERIFY(slider);
+            const qreal sliderLevel = slider->property("value").toReal();
+            QVERIFY(!qFuzzyCompare(sliderLevel, steppedLevel));
+            // Level round-trips through a MAVLink float
+            QVERIFY_TRUE_WAIT(qAbs(camera->zoomLevel() - sliderLevel) < 0.001, TestTimeout::mediumMs());
+        });
+}

--- a/test/QmlUITests/FlyViewCameraZoomUITest.h
+++ b/test/QmlUITests/FlyViewCameraZoomUITest.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+/// UI test for the FlyView camera zoom slider (PhotoVideoControl). Verifies the
+/// slider follows a camera-reported zoom level without echoing it back as a new
+/// zoom command, and that user interaction with the slider still commands the camera.
+class FlyViewCameraZoomUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+private slots:
+    void _testZoomSliderTracksCameraWithoutEcho();
+};


### PR DESCRIPTION
Cherry-pick of #15071 to Stable_V5.1 (fixes #15024 on the stable line).

Clean cherry-pick of 4fd86f9aee315397c29d2d5dde031d90c73f7673 (`-x`); only a trivial auto-merge in `test/QmlUITests/CMakeLists.txt`. Built locally on Stable_V5.1 with warnings-as-errors.

### Problem

The PhotoVideoControl zoom slider bound `value` to `_camera.zoomLevel` and also wrote it back on `onValueChanged`, so any camera-reported zoom level was re-sent as a `SET_CAMERA_ZOOM` command, looping and fighting joystick step/continuous zoom. Visible in 5.1 since 11b2afacff re-requests CAMERA_SETTINGS after each zoom ack.

### Fix

Use `onMoved` instead of `onValueChanged` so only interactive slider movement sends a command.

### Test

Adds `FlyViewCameraZoomUITest` (real FlyView UI + MockLink camera) covering camera→slider without echo and slider→camera. `MockLinkCamera` models `ZOOM_TYPE_STEP`.
