### PR TITLE
fix(Camera): stop timelapse capture from the shutter button

### DIFF
--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -9,7 +9,6 @@
 #include "FTPManager.h"
 #include "QGCCompression.h"
 #include "QGCCorePlugin.h"
-#include "QGCFileHelper.h"
 #include "AppMessages.h"
 #include "QGCFormat.h"
 #include "Vehicle.h"
@@ -459,14 +458,16 @@ bool VehicleCameraControl::takePhoto()
         (_cameraMode != CAM_MODE_VIDEO || photosInVideoMode());
 
     if (canUseMavlinkImageCapture) {
+        const bool timelapse = _photoCaptureMode == PHOTO_CAPTURE_TIMELAPSE;
         _vehicle->sendMavCommand(
             _compID,
             MAV_CMD_IMAGE_START_CAPTURE,
-            true,                           // ShowError
-            0,                              // All cameras
-            static_cast<float>(_photoCaptureMode == PHOTO_CAPTURE_SINGLE ? 0 : _photoLapse),   // Duration between two consecutive pictures (in seconds--ignored if single image)
-            _photoCaptureMode == PHOTO_CAPTURE_SINGLE ? 1 : _photoLapseCount);                 // Number of images to capture total - 0 for unlimited capture
-        _setPhotoCaptureStatus(PHOTO_CAPTURE_IN_PROGRESS);
+            true,                                           // ShowError
+            0,                                              // All cameras
+            static_cast<float>(timelapse ? _photoLapse : 0),   // Duration between two consecutive pictures (in seconds--ignored if single image)
+            timelapse ? _photoLapseCount : 1);              // Number of images to capture total - 0 for unlimited capture
+        // Interval state must be visible immediately so the shutter can stop the sequence before the camera reports status
+        _setPhotoCaptureStatus(timelapse ? PHOTO_CAPTURE_INTERVAL_IDLE : PHOTO_CAPTURE_IN_PROGRESS);
         _captureInfoRetries = 0;
         return true;
     } else {
@@ -1672,17 +1673,12 @@ void VehicleCameraControl::handleCameraCaptureStatus(const mavlink_camera_captur
     //-- Keep asking for it once in a while when recording
     if(_videoCaptureStatus() == VIDEO_CAPTURE_STATUS_RUNNING) {
         _captureStatusTimer.start(5000);
-    //-- Same while (single) image capture is busy
-    } else if(_photoCaptureStatus() != PHOTO_CAPTURE_IDLE && photoCaptureMode() == PHOTO_CAPTURE_SINGLE) {
+    //-- Same while a single image capture is busy
+    } else if(_photoCaptureStatus() == PHOTO_CAPTURE_IN_PROGRESS) {
         _captureStatusTimer.start(1000);
-    }
-    //-- Time Lapse
-    if(_photoCaptureStatus() == PHOTO_CAPTURE_INTERVAL_IDLE || _photoCaptureStatus() == PHOTO_CAPTURE_INTERVAL_IN_PROGRESS) {
-        //-- Capture local image as well
-        const QString photoDir = SettingsManager::instance()->appSettings()->savePath()->rawValue().toString() + QStringLiteral("/Photo");
-        QGCFileHelper::ensureDirectoryExists(photoDir);
-        const QString photoPath = photoDir + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss.zzz") + ".jpg";
-        VideoManager::instance()->grabImage(photoPath);
+    //-- Interval capture can run for hours; poll at the video cadence
+    } else if(_photoCaptureStatus() == PHOTO_CAPTURE_INTERVAL_IDLE || _photoCaptureStatus() == PHOTO_CAPTURE_INTERVAL_IN_PROGRESS) {
+        _captureStatusTimer.start(5000);
     }
 }
 

--- a/src/Comms/MockLink/MockLinkCamera.cc
+++ b/src/Comms/MockLink/MockLinkCamera.cc
@@ -107,7 +107,26 @@ void MockLinkCamera::run10HzTasks()
 
             qCDebug(MockLinkCameraLog) << "Camera" << cam->compId << "single-shot complete, total:" << cam->imagesCaptured;
             _sendCameraImageCaptured(cam->compId);
-            _sendCameraCaptureStatus(cam->compId);
+        }
+
+        // Interval capture: one image per interval
+        if (cam->image_status == ImageCaptureInterval || cam->image_status == ImageCaptureIntervalCapture) {
+            const qint64 intervalMs = static_cast<qint64>(cam->image_interval * 1000.0f);
+            if ((now - cam->intervalLastCaptureMs) >= intervalMs) {
+                cam->intervalLastCaptureMs = now;
+                cam->imagesCaptured++;
+                cam->image_status = ImageCaptureIntervalCapture;
+                qCDebug(MockLinkCameraLog) << "Camera" << cam->compId << "interval capture, total:" << cam->imagesCaptured;
+                _sendCameraImageCaptured(cam->compId);
+
+                if (cam->intervalRemaining > 0 && --cam->intervalRemaining == 0) {
+                    cam->image_status = ImageCaptureIdle;
+                    cam->image_interval = 0.0f;
+                    qCDebug(MockLinkCameraLog) << "Camera" << cam->compId << "interval capture complete";
+                }
+            } else {
+                cam->image_status = ImageCaptureInterval;
+            }
         }
 
         // Send periodic tracking image status (with simulated drift)
@@ -272,12 +291,12 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
             const float interval = request.param2;
             const int count = static_cast<int>(request.param3);
 
-            // Set capture status based on interval
             if (interval > 0) {
-                // Interval capture mode
-                cam->image_status = ImageCaptureIntervalCapture;
+                // First interval image is captured on the next 10Hz tick
+                cam->image_status = ImageCaptureInterval;
                 cam->image_interval = interval;
-                cam->imagesCaptured += (count > 0) ? count : 1;
+                cam->intervalRemaining = count;
+                cam->intervalLastCaptureMs = 0;
                 cam->singleShotStartMs = 0;
             } else {
                 // Single shot - start capture, count will increment after 0.5s
@@ -289,8 +308,6 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
             qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "image capture started"
                                     << "interval:" << interval << "count:" << count;
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
-            // Send capture status update
-            _sendCameraCaptureStatus(targetCompId);
         } else {
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_DENIED);
         }
@@ -300,10 +317,10 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
         if (cam->capFlags & CAMERA_CAP_FLAGS_CAPTURE_IMAGE) {
             cam->image_status = ImageCaptureIdle;
             cam->image_interval = 0.0f;
+            cam->intervalRemaining = 0;
             cam->singleShotStartMs = 0;
             qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "image capture stopped";
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
-            _sendCameraCaptureStatus(targetCompId);
         } else {
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_DENIED);
         }
@@ -321,7 +338,6 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
             cam->recording = true;
             qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "video recording started";
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
-            _sendCameraCaptureStatus(targetCompId);
         } else {
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_DENIED);
         }
@@ -332,7 +348,6 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
             cam->recording = false;
             qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "video recording stopped";
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
-            _sendCameraCaptureStatus(targetCompId);
         } else {
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_DENIED);
         }
@@ -343,6 +358,7 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
         cam->imagesCaptured = 0;
         cam->image_status = ImageCaptureIdle;
         cam->image_interval = 0.0f;
+        cam->intervalRemaining = 0;
         cam->singleShotStartMs = 0;
         _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
         _sendStorageInformation(targetCompId);
@@ -382,6 +398,7 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
         cam->focusLevel = 0.0f;
         cam->image_status = ImageCaptureIdle;
         cam->image_interval = 0.0f;
+        cam->intervalRemaining = 0;
         cam->singleShotStartMs = 0;
         qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "settings reset";
         _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);

--- a/src/Comms/MockLink/MockLinkCamera.h
+++ b/src/Comms/MockLink/MockLinkCamera.h
@@ -32,6 +32,10 @@ class MockLink;
 ///
 /// Simulated storage: 16 GiB total, 8 GiB free, SD card.
 ///
+/// Spec-minimal (MAVLink camera protocol v2): CAMERA_CAPTURE_STATUS is only sent
+/// on request, never pushed after a command ack; the GCS must poll for it.
+/// CAMERA_IMAGE_CAPTURED is broadcast per captured image, as the protocol requires.
+///
 class MockLinkCamera
 {
 public:
@@ -55,6 +59,8 @@ public:
         uint8_t  image_status        = ImageCaptureIdle;     ///< ImageCaptureStatus enum
         float    image_interval      = 0.0f;                 ///< Interval between image captures (seconds)
         qint64   singleShotStartMs   = 0;                    ///< Timestamp when single-shot capture started (0 = not active)
+        int      intervalRemaining   = 0;                    ///< Images left in interval capture (0 = unlimited)
+        qint64   intervalLastCaptureMs = 0;                  ///< Timestamp of last interval capture
 
         // Tracking state
         uint8_t  trackingMode        = CAMERA_TRACKING_MODE_NONE; ///< CAMERA_TRACKING_MODE enum

--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -220,6 +220,7 @@ Rectangle {
                 // Take Photo button
                 Rectangle {
                     id: photoCaptureButton
+                    objectName: "photoVideoControl_photoCaptureButton"
                     Layout.alignment: Qt.AlignHCenter
                     color: photoCaptureButtonPalette.button
                     width: ScreenTools.defaultFontPixelWidth * 6

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -30,6 +30,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4AirframeSetupUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/AppCloseWarningUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/AppCloseWarningUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewCameraCaptureUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewCameraCaptureUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewCameraZoomUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewCameraZoomUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewProximityRadarUITest.cc
@@ -68,6 +70,7 @@ add_qgc_test(APMSensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 
 add_qgc_test(APMFreshFlashUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(PX4AirframeSetupUITest LABELS Integration NoSanitizer StockUI TIMEOUT 120)
 add_qgc_test(AppCloseWarningUITest LABELS Integration NoSanitizer TIMEOUT 120)
+add_qgc_test(FlyViewCameraCaptureUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(FlyViewCameraZoomUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(FlyViewProximityRadarUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(FlyViewROIUITest LABELS Integration NoSanitizer TIMEOUT 120)

--- a/test/QmlUITests/FlyViewCameraCaptureUITest.cc
+++ b/test/QmlUITests/FlyViewCameraCaptureUITest.cc
@@ -1,0 +1,71 @@
+#include "FlyViewCameraCaptureUITest.h"
+
+#include <QtTest/QTest>
+
+#include "MavlinkCameraControlInterface.h"
+#include "MockLink.h"
+#include "QGCCameraManager.h"
+#include "Vehicle.h"
+
+UT_REGISTER_TEST(FlyViewCameraCaptureUITest, TestLabel::Integration)
+
+void FlyViewCameraCaptureUITest::_testTimelapseShutterStopsCapture()
+{
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(MockConfiguration::OptionEnableCamera); },
+        [this](QPointer<MockLink> mockLink, Vehicle* vehicle) {
+            QGCCameraManager* const cameraManager = vehicle->cameraManager();
+            QVERIFY(cameraManager);
+
+            auto findCamera = [cameraManager]() -> MavlinkCameraControlInterface* {
+                for (int i = 0; i < cameraManager->cameras()->count(); i++) {
+                    auto* const cam = qobject_cast<MavlinkCameraControlInterface*>(cameraManager->cameras()->get(i));
+                    if (cam && (cam->compID() == MAV_COMP_ID_CAMERA)) {
+                        return cam;
+                    }
+                }
+                return nullptr;
+            };
+            MavlinkCameraControlInterface* camera = nullptr;
+            QVERIFY_TRUE_WAIT((camera = findCamera()) != nullptr, TestTimeout::longMs());
+            QVERIFY(camera->capturesPhotos());
+            QVERIFY_TRUE_WAIT(camera->capturePhotosState() == MavlinkCameraControlInterface::CapturePhotosStateIdle,
+                              TestTimeout::longMs());
+
+            cameraManager->setCurrentCamera(cameraManager->cameras()->indexOf(camera));
+            QCOMPARE(cameraManager->currentCameraInstance(), camera);
+
+            // Mock camera 1 starts in video mode; the shutter button is only shown in photo mode
+            camera->setCameraModePhoto();
+            QVERIFY_TRUE_WAIT(camera->cameraMode() == MavlinkCameraControlInterface::CAM_MODE_PHOTO,
+                              TestTimeout::mediumMs());
+
+            camera->setPhotoCaptureMode(MavlinkCameraControlInterface::PHOTO_CAPTURE_TIMELAPSE);
+            camera->setPhotoLapse(1.0);
+            camera->setPhotoLapseCount(0);
+
+            const QString buttonName = QStringLiteral("photoVideoControl_photoCaptureButton");
+            QVERIFY2(findVisibleItem(_rootItem, buttonName, TestTimeout::mediumMs()),
+                     "Photo capture button never became visible");
+
+            auto startCount = [&mockLink] {
+                return mockLink->receivedMavCommandCount(MAV_CMD_IMAGE_START_CAPTURE, MAV_COMP_ID_CAMERA);
+            };
+            auto stopCount = [&mockLink] {
+                return mockLink->receivedMavCommandCount(MAV_CMD_IMAGE_STOP_CAPTURE, MAV_COMP_ID_CAMERA);
+            };
+            QCOMPARE(startCount(), 0);
+            QCOMPARE(stopCount(), 0);
+
+            QVERIFY(clickItemFraction(buttonName, 0.5, 0.5));
+            QVERIFY_TRUE_WAIT(startCount() == 1, TestTimeout::mediumMs());
+            // Camera broadcasts CAMERA_IMAGE_CAPTURED per interval shot, which drives the photo counter
+            QVERIFY_TRUE_WAIT(vehicle->cameraTriggerPoints()->count() >= 1, TestTimeout::mediumMs());
+
+            // Second click while the interval capture is running must stop it
+            QVERIFY(clickItemFraction(buttonName, 0.5, 0.5));
+            QVERIFY_TRUE_WAIT(stopCount() == 1, TestTimeout::mediumMs());
+            QVERIFY_TRUE_WAIT(camera->capturePhotosState() == MavlinkCameraControlInterface::CapturePhotosStateIdle,
+                              TestTimeout::mediumMs());
+        });
+}

--- a/test/QmlUITests/FlyViewCameraCaptureUITest.h
+++ b/test/QmlUITests/FlyViewCameraCaptureUITest.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+/// UI test for the FlyView shutter button (PhotoVideoControl) in timelapse mode.
+/// Verifies that a second click stops an interval capture (issue #15064).
+class FlyViewCameraCaptureUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+private slots:
+    void _testTimelapseShutterStopsCapture();
+};


### PR DESCRIPTION
Fixes #15064

## Problem

In timelapse mode, clicking the shutter a second time did nothing and `MAV_CMD_IMAGE_STOP_CAPTURE` was never sent. `VehicleCameraControl::takePhoto()` set `PHOTO_CAPTURE_IN_PROGRESS` for interval captures, so `capturePhotosState()` reported a *single* shot in progress and `PhotoVideoControl` ignored the click. The state only became `INTERVAL_*` once a `CAMERA_CAPTURE_STATUS` arrived, and after that QGC stopped polling in timelapse mode, so it could not resync either.

The existing MockLink camera hid this by pushing an unsolicited `CAMERA_CAPTURE_STATUS` right after every ack, something the Camera Protocol v2 does not require and which the reporter's camera evidently does not do.

## Changes

**`VehicleCameraControl`**
- `takePhoto()` sets `PHOTO_CAPTURE_INTERVAL_IDLE` immediately for timelapse so the shutter can stop the sequence before the camera reports status.
- `handleCameraCaptureStatus()` keeps polling while an interval capture is active (5 s, same cadence as video recording); single shot remains 1 s.

**`MockLinkCamera`** — now spec-minimal
- No unsolicited `CAMERA_CAPTURE_STATUS` after `IMAGE_START/STOP_CAPTURE`, `VIDEO_START/STOP_CAPTURE`, or single-shot completion. Status is sent only on request.
- Interval capture is simulated per shot: `image_count` increments and `CAMERA_IMAGE_CAPTURED` is broadcast for each image (required by the protocol), finite counts auto-idle.

**`PhotoVideoControl.qml`** — `objectName` on the shutter button (test hook only).

**New test** `FlyViewCameraCaptureUITest`: drives the real FlyView shutter with the mock camera in timelapse mode, verifies `START_CAPTURE`, that the photo counter increments, and that the second click sends `STOP_CAPTURE`. Fails on `master`, passes with this change.

## Not addressed

The "image counter not updated" symptom in the issue depends on the camera broadcasting `CAMERA_IMAGE_CAPTURED` per image (spec-required). If it persists after this fix, that is a camera-side issue.

The local `VideoManager::grabImage()` triggered from `handleCameraCaptureStatus()` during timelapse is pre-existing and now runs every 5 s; keying it off `CAMERA_IMAGE_CAPTURED` instead is a candidate follow-up.
