### PR TITLE
Fix ArduPilot lua script list directory not working

### DIFF
--- a/src/Comms/MockLink/MockLinkFTP.cc
+++ b/src/Comms/MockLink/MockLinkFTP.cc
@@ -49,7 +49,7 @@ void MockLinkFTP::_listCommand(uint8_t senderSystemId, uint8_t senderComponentId
 
     if (withTime && !_listDirectoryWithTimeSupported) {
         // Simulate a server which doesn't implement the command. The client should fall back to kCmdListDirectory.
-        _sendNak(senderSystemId, senderComponentId, MavlinkFTP::kErrUnknownCommand, outgoingSeqNumber, listOpCode);
+        _sendNak(senderSystemId, senderComponentId, _listDirectoryWithTimeNakError, outgoingSeqNumber, listOpCode);
         return;
     }
 

--- a/src/Comms/MockLink/MockLinkFTP.h
+++ b/src/Comms/MockLink/MockLinkFTP.h
@@ -78,8 +78,12 @@ public:
     void setErrorMode(ErrorMode_t errMode) { _errMode = errMode; };
 
     /// Controls whether the server implements the kCmdListDirectoryWithTime command. When false the
-    /// server Naks it with kErrUnknownCommand so the client fallback to kCmdListDirectory can be tested.
+    /// server Naks it (see setListDirectoryWithTimeNakError) so the client fallback to kCmdListDirectory can be tested.
     void setListDirectoryWithTimeSupported(bool supported) { _listDirectoryWithTimeSupported = supported; }
+
+    /// Error code used to Nak kCmdListDirectoryWithTime when unsupported. PX4 replies kErrUnknownCommand,
+    /// ArduPilot replies kErrFail.
+    void setListDirectoryWithTimeNakError(MavlinkFTP::ErrorCode_t error) { _listDirectoryWithTimeNakError = error; }
 
     /// Array of failure modes you can cycle through for testing. By looping through this array you can avoid
     /// hardcoding the specific error modes in your unit test. This way when new error modes are added your unit test
@@ -148,6 +152,7 @@ private:
     int _burstReadDelayMs = 0;                  ///< Per-burst delay to simulate a slow link
     ErrorMode_t _errMode = errModeNone;         ///< Currently set error mode, as specified by setErrorMode
     bool _listDirectoryWithTimeSupported = true; ///< Whether the server implements kCmdListDirectoryWithTime
+    MavlinkFTP::ErrorCode_t _listDirectoryWithTimeNakError = MavlinkFTP::kErrUnknownCommand;
     bool _paramPckEnabled = true;               ///< Serve @PARAM/param.pck; false NAKs errno ENOENT
     mavlink_message_t _lastReply{};
     QFile _currentFile;

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -999,11 +999,14 @@ void FTPManager::_listDirectoryAckOrNak(const MavlinkFTP::Request* ackOrNak)
                 }
                 _advanceStateMachine();
             }
-        } else if (errorCode == MavlinkFTP::kErrUnknownCommand && _listDirectoryState.opCode == MavlinkFTP::kCmdListDirectoryWithTime) {
+        } else if (_listDirectoryState.opCode == MavlinkFTP::kCmdListDirectoryWithTime &&
+                   (errorCode == MavlinkFTP::kErrUnknownCommand ||
+                    (errorCode == MavlinkFTP::kErrFail && _listDirWithTimeSupport == WithTimeSupport_t::Unknown))) {
             // Server doesn't implement kCmdListDirectoryWithTime. Remember that, fall back to the
-            // plain listing and restart from the beginning. The UnknownCommand Nak is a definitive
-            // capability statement so we act on it without a strict sequence check; the restart is
-            // idempotent (offset and accumulated entries are reset).
+            // plain listing and restart from the beginning. ArduPilot Naks unknown opcodes with a
+            // generic kErrFail rather than kErrUnknownCommand, so kErrFail is also treated as
+            // unsupported while probing. We act on it without a strict sequence check; the restart
+            // is idempotent (offset and accumulated entries are reset).
             qCDebug(FTPManagerLog) << "_listDirectoryAckOrNak: kCmdListDirectoryWithTime unsupported, falling back to kCmdListDirectory";
             _listDirWithTimeSupport             = WithTimeSupport_t::Unsupported;
             _listDirectoryState.opCode          = MavlinkFTP::kCmdListDirectory;

--- a/test/Vehicle/FTPManagerTest.cc
+++ b/test/Vehicle/FTPManagerTest.cc
@@ -164,11 +164,22 @@ void FTPManagerTest::_testListDirectoryWithTime()
     _disconnectMockLink();
 }
 
+void FTPManagerTest::_testListDirectoryWithTimeFallback_data()
+{
+    QTest::addColumn<int>("nakError");
+
+    QTest::newRow("UnknownCommand (PX4)") << static_cast<int>(MavlinkFTP::kErrUnknownCommand);
+    QTest::newRow("Fail (ArduPilot)") << static_cast<int>(MavlinkFTP::kErrFail);
+}
+
 void FTPManagerTest::_testListDirectoryWithTimeFallback()
 {
+    QFETCH(int, nakError);
+
     _connectMockLinkNoInitialConnectSequence();
     FTPManager* ftpManager = _vehicle->ftpManager();
     _mockLink->mockLinkFTP()->setListDirectoryWithTimeSupported(false);
+    _mockLink->mockLinkFTP()->setListDirectoryWithTimeNakError(static_cast<MavlinkFTP::ErrorCode_t>(nakError));
     QSignalSpy spyListDirectoryComplete(ftpManager, &FTPManager::listDirectoryComplete);
     ftpManager->listDirectory(MAV_COMP_ID_AUTOPILOT1, "/");
     QVERIFY_SIGNAL_WAIT(spyListDirectoryComplete, TestTimeout::longMs());
@@ -177,11 +188,35 @@ void FTPManagerTest::_testListDirectoryWithTimeFallback()
     const QStringList entries = arguments[0].toStringList();
     QCOMPARE(entries.count(), 6);
     QVERIFY(arguments[1].toString().isEmpty());
+    QVERIFY(ftpManager->listDirectoryWithTimeUnsupported());
 
     // After falling back to kCmdListDirectory the entries carry no modification-time field.
     for (const QString &entry : entries) {
         QCOMPARE(entry.mid(1).count(QLatin1Char('\t')), 1);
     }
+    _disconnectMockLink();
+}
+
+void FTPManagerTest::_testListDirectoryWithTimeFailAfterSupported()
+{
+    _connectMockLinkNoInitialConnectSequence();
+    FTPManager* ftpManager = _vehicle->ftpManager();
+    QSignalSpy spyListDirectoryComplete(ftpManager, &FTPManager::listDirectoryComplete);
+
+    // First listing establishes kCmdListDirectoryWithTime support
+    ftpManager->listDirectory(MAV_COMP_ID_AUTOPILOT1, "/");
+    QVERIFY_SIGNAL_WAIT(spyListDirectoryComplete, TestTimeout::longMs());
+    QVERIFY(spyListDirectoryComplete.takeFirst()[1].toString().isEmpty());
+
+    // Once support is known a kErrFail Nak is a real failure, not a reason to fall back
+    _mockLink->mockLinkFTP()->setListDirectoryWithTimeSupported(false);
+    _mockLink->mockLinkFTP()->setListDirectoryWithTimeNakError(MavlinkFTP::kErrFail);
+    ftpManager->listDirectory(MAV_COMP_ID_AUTOPILOT1, "/");
+    QVERIFY_SIGNAL_WAIT(spyListDirectoryComplete, TestTimeout::longMs());
+    QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
+    QCOMPARE(arguments[0].toStringList().count(), 0);
+    QVERIFY(!arguments[1].toString().isEmpty());
+    QVERIFY(!ftpManager->listDirectoryWithTimeUnsupported());
     _disconnectMockLink();
 }
 

--- a/test/Vehicle/FTPManagerTest.h
+++ b/test/Vehicle/FTPManagerTest.h
@@ -14,7 +14,9 @@ private slots:
     void _testLostPackets();
     void _testListDirectory();
     void _testListDirectoryWithTime();
+    void _testListDirectoryWithTimeFallback_data();
     void _testListDirectoryWithTimeFallback();
+    void _testListDirectoryWithTimeFailAfterSupported();
     void _testListDirectoryNoResponse();
     void _testListDirectoryNakResponse();
     void _testListDirectoryNoSecondResponse();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->

When testing the ArduPilot lua scripting feature, listing directory would never work. I traced back the issue and found out that it was introduced here: https://github.com/mavlink/qgroundcontrol/pull/14495

- ArduPilot does not support ListDirectoryWithTime
- The fallback only happened if we got kErrUnknownCommand, but ArduPilot
  gives kErrFail.

My solution: We also listen for kErrFail for the callback.

**Known flaw of this solution:** If a vehicle ever gives kErrFail from a genuine failure rather than unknown command, QGC will mistakenly remember that ListDirectoryWithTime is unsupported. However, I don't believe PX4 or ArduPilot behave this way.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).