### PR TITLE
Do not build the camera cache path out of vehicle-supplied strings

### DIFF
--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -19,6 +19,8 @@
 #include "QGCVideoStreamInfo.h"
 #include "MissionCommandTree.h"
 
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtCore/QDir>
 
@@ -106,6 +108,60 @@ static bool read_value(QDomNode& element, const char* tagName, QString& target)
     return true;
 }
 
+QString VehicleCameraControl::boundedNameField(const uint8_t *raw, size_t maxLen)
+{
+    if ((raw == nullptr) || (maxLen == 0)) {
+        return QString();
+    }
+
+    const char *chars = reinterpret_cast<const char*>(raw);
+    const qsizetype length = static_cast<qsizetype>(qstrnlen(chars, maxLen));
+    return QString::fromLatin1(chars, length);
+}
+
+QString VehicleCameraControl::pathSafeNameToken(const QString &name)
+{
+    QString token = name;
+
+    for (QChar &ch : token) {
+        const char16_t c = ch.unicode();
+        const bool safe = ((c >= u'A') && (c <= u'Z'))
+                       || ((c >= u'a') && (c <= u'z'))
+                       || ((c >= u'0') && (c <= u'9'))
+                       || (c == u'.') || (c == u'-') || (c == u'_');
+        if (!safe) {
+            ch = QLatin1Char('_');
+        }
+    }
+
+    // A leading dot lets a token of only dots act as a relative path element, and Win32
+    // strips trailing dots silently, which would change the name after validation.
+    while (token.startsWith(QLatin1Char('.'))) {
+        token.remove(0, 1);
+    }
+    while (token.endsWith(QLatin1Char('.'))) {
+        token.chop(1);
+    }
+
+    if (token.isEmpty()) {
+        token = QStringLiteral("unknown");
+    }
+
+    return token;
+}
+
+bool VehicleCameraControl::pathIsInside(const QString &baseDir, const QString &candidate)
+{
+    if (baseDir.isEmpty() || candidate.isEmpty()) {
+        return false;
+    }
+
+    // cleanPath() also normalises '\' to '/' on Windows, so this holds on every platform.
+    const QString base = QDir::cleanPath(QDir(baseDir).absolutePath());
+    const QString resolved = QDir::cleanPath(QFileInfo(candidate).absoluteFilePath());
+    return resolved.startsWith(base + QLatin1Char('/'));
+}
+
 VehicleCameraControl::VehicleCameraControl(const mavlink_camera_information_t *info, Vehicle* vehicle, int compID, QObject* parent)
     : MavlinkCameraControlInterface(vehicle, parent)
     , _compID(compID)
@@ -114,13 +170,25 @@ VehicleCameraControl::VehicleCameraControl(const mavlink_camera_information_t *i
 
     memcpy(&_mavlinkCameraInfo, info, sizeof(mavlink_camera_information_t));
 
-    _vendor = QString(reinterpret_cast<const char*>(info->vendor_name));
-    _modelName = QString(reinterpret_cast<const char*>(info->model_name));
-    _cacheFile = QString::asprintf("%s/%s_%s_%03d.xml",
-                                    SettingsManager::instance()->appSettings()->parameterSavePath().toStdString().c_str(),
-                                    _vendor.toStdString().c_str(),
-                                    _modelName.toStdString().c_str(),
+    // vendor_name and model_name are uint8_t[32] filled straight from the wire by an
+    // unauthenticated peer, with no NUL guarantee. Bound the read, and keep the display
+    // strings as sent; only the file-name tokens are reduced to a safe character set.
+    _vendor = boundedNameField(info->vendor_name, sizeof(info->vendor_name));
+    _modelName = boundedNameField(info->model_name, sizeof(info->model_name));
+
+    _cacheFileToken = QString::asprintf("%s_%s_%03d",
+                                    pathSafeNameToken(_vendor).toStdString().c_str(),
+                                    pathSafeNameToken(_modelName).toStdString().c_str(),
                                     static_cast<int>(_mavlinkCameraInfo.cam_definition_version));
+
+    const QString cacheDir = SettingsManager::instance()->appSettings()->parameterSavePath();
+    const QString cacheCandidate = QDir(cacheDir).filePath(_cacheFileToken + QStringLiteral(".xml"));
+    if (pathIsInside(cacheDir, cacheCandidate)) {
+        _cacheFile = QDir::cleanPath(cacheCandidate);
+    } else {
+        qCWarning(VehicleCameraControlLog) << "Refusing camera cache path outside" << cacheDir << ":" << cacheCandidate;
+        _cacheFile.clear();
+    }
 
     connect(this, &VehicleCameraControl::dataReady, this, &VehicleCameraControl::_dataReady);
 
@@ -2192,15 +2260,12 @@ void VehicleCameraControl::_handleDefinitionFile(const QString &url)
     QString ftpPrefix(QStringLiteral("%1://").arg(FTPManager::mavlinkFTPScheme));
     if (!xmlFile.exists() && url.startsWith(ftpPrefix, Qt::CaseInsensitive)) {
         qCDebug(VehicleCameraControlLog) << "No camera definition file cached, attempt ftp download";
-        int ver = static_cast<int>(_mavlinkCameraInfo.cam_definition_version);
         QString ext = "";
         if (url.endsWith(".lzma", Qt::CaseInsensitive)) { ext = ".lzma"; }
         if (url.endsWith(".xz", Qt::CaseInsensitive)) { ext = ".xz"; }
-        QString fileName = QString::asprintf("%s_%s_%03d.xml%s",
-            _vendor.toStdString().c_str(),
-            _modelName.toStdString().c_str(),
-            ver,
-            ext.toStdString().c_str());
+        // Built from the sanitised token, not from the raw vendor/model strings, so the
+        // vehicle cannot steer FTPManager's toDir.filePath() join out of the cache folder.
+        QString fileName = _cacheFileToken + QStringLiteral(".xml") + ext;
         connect(_vehicle->ftpManager(), &FTPManager::downloadComplete, this, &VehicleCameraControl::_ftpDownloadComplete);
         _vehicle->ftpManager()->download(_compID, url,
             SettingsManager::instance()->appSettings()->parameterSavePath().toStdString().c_str(),

--- a/src/Camera/VehicleCameraControl.h
+++ b/src/Camera/VehicleCameraControl.h
@@ -45,6 +45,19 @@ public:
     VehicleCameraControl(const mavlink_camera_information_t* info, Vehicle* vehicle, int compID, QObject* parent = nullptr);
     ~VehicleCameraControl() override;
 
+    /// Read a fixed-size CAMERA_INFORMATION name field without running off the end of it.
+    /// MAVLink does not guarantee these arrays are NUL terminated, so the length is bounded
+    /// by the array itself rather than by strlen().
+    static QString boundedNameField(const uint8_t *raw, size_t maxLen);
+
+    /// Reduce a vehicle-supplied name to something safe to embed in a file name. Everything
+    /// that could act as a path separator, a drive or NTFS stream qualifier, or a directory
+    /// traversal is replaced.
+    static QString pathSafeNameToken(const QString &name);
+
+    /// True when candidate resolves to a location inside baseDir.
+    static bool pathIsInside(const QString &baseDir, const QString &candidate);
+
     Q_INVOKABLE void setCameraModeVideo() override;
     Q_INVOKABLE void setCameraModePhoto() override;
     Q_INVOKABLE void toggleCameraMode       () override;
@@ -270,6 +283,7 @@ protected:
     QString                             _modelName;
     QString                             _vendor;
     QString                             _cacheFile;
+    QString                             _cacheFileToken;    ///< sanitised "<vendor>_<model>_<NNN>", no extension
     StorageStatus                       _storageStatus      = STORAGE_NOT_SUPPORTED;
     QStringList                         _activeSettings;
     QStringList                         _settings;

--- a/test/Camera/VehicleCameraControlTest.cc
+++ b/test/Camera/VehicleCameraControlTest.cc
@@ -1,6 +1,13 @@
 #include "VehicleCameraControlTest.h"
 #include <QtTest/QSignalSpy>
 
+#include <cstring>
+
+#include <QtCore/QDir>
+#include <QtCore/QTemporaryDir>
+
+#include "VehicleCameraControl.h"
+
 
 #include "LinkManager.h"
 #include "MavlinkCameraControlInterface.h"
@@ -9,6 +16,79 @@
 #include "MultiVehicleManager.h"
 #include "QGCCameraManager.h"
 #include "Vehicle.h"
+
+void VehicleCameraControlTest::_testNameFieldReadIsBounded()
+{
+    // CAMERA_INFORMATION.vendor_name and model_name are uint8_t[32] filled straight from
+    // the wire. MAVLink does not guarantee a NUL, so reading them as C strings runs past
+    // the array into whatever follows it in the struct.
+    struct { uint8_t vendor[32]; uint8_t model[32]; } wire{};
+    memset(wire.vendor, 'A', sizeof(wire.vendor));
+    memcpy(wire.model, "SHOULD_NOT_APPEAR", 18);
+
+    const QString bounded = VehicleCameraControl::boundedNameField(wire.vendor, sizeof(wire.vendor));
+
+    QCOMPARE(bounded.length(), 32);
+    QVERIFY(!bounded.contains(QLatin1String("SHOULD_NOT_APPEAR")));
+
+    // A short, properly terminated field must still read normally.
+    memset(&wire, 0, sizeof(wire));
+    memcpy(wire.vendor, "Sony", 5);
+    QCOMPARE(VehicleCameraControl::boundedNameField(wire.vendor, sizeof(wire.vendor)),
+             QStringLiteral("Sony"));
+
+    QVERIFY(VehicleCameraControl::boundedNameField(nullptr, 32).isEmpty());
+}
+
+void VehicleCameraControlTest::_testCameraNamesCannotSteerCachePath()
+{
+    // The vendor/model strings are formatted into the camera-definition cache file name.
+    // Whatever they contain, the result has to stay a single component inside the cache
+    // directory.
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString base = QDir::cleanPath(QDir(tempDir.path()).absolutePath());
+
+    const QList<QPair<QString, QString>> hostile = {
+        { QStringLiteral("../../../Desktop/QGC01_PWNED"), QStringLiteral("marker") },
+        { QStringLiteral("..\\..\\..\\Desktop\\PWNED"),   QStringLiteral("marker") },
+        { QStringLiteral("C:\\Windows\\Temp\\PWNED"),     QStringLiteral("marker") },
+        { QStringLiteral("/etc/cron.d/PWNED"),            QStringLiteral("marker") },
+        { QStringLiteral("T.txt:"),                       QStringLiteral("s") },
+        { QStringLiteral("vendor"),                       QStringLiteral("../../evil") },
+        { QStringLiteral(".."),                           QStringLiteral("..") },
+        { QString(),                                      QStringLiteral("marker") },
+    };
+
+    for (const auto &testCase : hostile) {
+        const QString token = QString::asprintf("%s_%s_%03d",
+            VehicleCameraControl::pathSafeNameToken(testCase.first).toStdString().c_str(),
+            VehicleCameraControl::pathSafeNameToken(testCase.second).toStdString().c_str(),
+            1);
+        const QString candidate = QDir(base).filePath(token + QStringLiteral(".xml"));
+
+        QVERIFY2(VehicleCameraControl::pathIsInside(base, candidate), qPrintable(candidate));
+
+        // It must be one component: no separator, and no drive or NTFS stream qualifier.
+        QVERIFY2(!token.contains(QLatin1Char('/')), qPrintable(token));
+        QVERIFY2(!token.contains(QLatin1Char('\\')), qPrintable(token));
+        QVERIFY2(!token.contains(QLatin1Char(':')), qPrintable(token));
+    }
+
+    // An unset cache directory must be refused rather than becoming a write at "/".
+    QVERIFY(!VehicleCameraControl::pathIsInside(QString(), QStringLiteral("/v_m_001.xml")));
+}
+
+void VehicleCameraControlTest::_testOrdinaryCameraNamesUnchanged()
+{
+    // Containment must not mangle a real camera's cache file name beyond replacing
+    // characters that cannot appear in one.
+    QCOMPARE(VehicleCameraControl::pathSafeNameToken(QStringLiteral("Sony")), QStringLiteral("Sony"));
+    QCOMPARE(VehicleCameraControl::pathSafeNameToken(QStringLiteral("ILCE-7RM4")), QStringLiteral("ILCE-7RM4"));
+    QCOMPARE(VehicleCameraControl::pathSafeNameToken(QStringLiteral("Skynode.v2")), QStringLiteral("Skynode.v2"));
+    QCOMPARE(VehicleCameraControl::pathSafeNameToken(QStringLiteral("FLIR Boson")), QStringLiteral("FLIR_Boson"));
+    QCOMPARE(VehicleCameraControl::pathSafeNameToken(QString()), QStringLiteral("unknown"));
+}
 
 void VehicleCameraControlTest::initTestCase()
 {

--- a/test/Camera/VehicleCameraControlTest.h
+++ b/test/Camera/VehicleCameraControlTest.h
@@ -16,6 +16,9 @@ private slots:
 
     UT_PARAMETERIZED_TEST(_testCameraCapFlags);
     void _testZoomTriggersCameraSettingsRequest();
+    void _testNameFieldReadIsBounded();
+    void _testCameraNamesCannotSteerCachePath();
+    void _testOrdinaryCameraNamesUnchanged();
 
 private:
     MockLink* _mockLink = nullptr;


### PR DESCRIPTION
## Description

Related to: https://github.com/nicholasaleks/infected-drones/tree/main/QGC-01_camera_info_path_traversal_write

CAMERA_INFORMATION.vendor_name and model_name are uint8_t[32] filled straight from the wire by an unauthenticated peer. Both were read as C strings and then asprintf'd into the camera-definition cache path:

    _cacheFile = QString::asprintf("%s/%s_%s_%03d.xml",
                                   parameterSavePath(), _vendor, _modelName, ...);

Two problems. MAVLink does not guarantee those arrays are NUL terminated, so a field that is exactly full makes QString/strlen run past it into the rest of the struct. And asprintf does no path normalisation, while parameterSavePath() is built with QDir::filePath() and never collapses "..", so a vendor name of "../../../Desktop/x" places the cache file anywhere the QGC user can write. The same strings are formatted into the file name handed to FTPManager::download(), which joins it with plain concatenation, so the MAVLink-FTP route writes the downloaded bytes to the traversed path with no parsing at all.

  - boundedNameField(): read the fixed field with qstrnlen() bounded by the array size. _vendor and _modelName keep the string as sent, so displayed names are unaffected.
  - pathSafeNameToken(): reduce a name to [A-Za-z0-9._-] for use in a file name, strip leading and trailing dots, and fall back to "unknown" when nothing is left. Applied only to the path token, not to the display strings.
  - pathIsInside(): verify the assembled path resolves inside the cache directory, and refuse rather than fix up. This also covers the case where parameterSavePath() is empty, which previously produced "/vendor_model_001.xml" at the filesystem root.
  - _handleDefinitionFile(): build the FTP file name from the sanitised token, so the vehicle cannot steer FTPManager's toDir join either.

Adds three tests: the bounded read of an unterminated field, a hostile vendor/model corpus that must stay inside the cache directory, and ordinary camera names which must come through unchanged.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [ ] Windows
- [x] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
- [ ] PX4
- [ ] ArduPilot

## Screenshots
Related to: https://github.com/nicholasaleks/infected-drones/tree/main/QGC-01_camera_info_path_traversal_write

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally


---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
