### PR TITLE
Do not let a remote URL name a download's directory, or clobber it on…

### DIFF
--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -2240,10 +2240,10 @@ void VehicleCameraControl::_httpRequest(const QString &url)
     }
     QGCNetworkHelper::configureProxy(_netManager);
     QNetworkRequest request(QUrl::fromUserInput(url));
-    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, true);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
+    // cam_definition_uri comes from an unauthenticated vehicle: validate the peer and do
+    // not follow a redirect that downgrades the connection.
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::NoLessSafeRedirectPolicy);
     QNetworkReply* reply = _netManager->get(request);
     connect(reply, &QNetworkReply::finished,  this, &VehicleCameraControl::_downloadFinished);
 }

--- a/src/Utilities/Network/QGCFileDownload.cc
+++ b/src/Utilities/Network/QGCFileDownload.cc
@@ -6,6 +6,7 @@
 
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
+#include <QtCore/QSaveFile>
 #include <QtCore/QStandardPaths>
 #include <QtNetwork/QNetworkAccessManager>
 
@@ -131,9 +132,11 @@ bool QGCFileDownload::start(const QString &remoteUrl, const QGCNetworkHelper::Re
         return false;
     }
 
-    // Open output file for streaming write
-    _outputFile = new QFile(_localPath, this);
-    if (!_outputFile->open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    // Open output file for streaming write. QSaveFile writes to a temporary and only
+    // replaces _localPath on commit(), so a download that fails cannot destroy an
+    // existing file there.
+    _outputFile = new QSaveFile(_localPath, this);
+    if (!_outputFile->open(QIODevice::WriteOnly)) {
         _setErrorString(tr("Cannot open output file: %1").arg(_outputFile->errorString()));
         delete _outputFile;
         _outputFile = nullptr;
@@ -152,7 +155,6 @@ bool QGCFileDownload::start(const QString &remoteUrl, const QGCNetworkHelper::Re
     if (_currentReply == nullptr) {
         qCWarning(QGCFileDownloadLog) << "QNetworkAccessManager::get failed";
         _setErrorString(tr("Failed to start download"));
-        _outputFile->close();
         delete _outputFile;
         _outputFile = nullptr;
         return false;
@@ -248,25 +250,20 @@ void QGCFileDownload::_onDownloadFinished()
 
     _lastResultFromCache = reply->attribute(QNetworkRequest::SourceIsFromCacheAttribute).toBool();
 
-    // Close output file
+    // Write any remaining data, but leave the file uncommitted: nothing replaces
+    // _localPath until the reply below is known good.
     if (_outputFile != nullptr) {
-        // Write any remaining data
         const QByteArray remaining = reply->readAll();
         if (!_writeReplyData(remaining)) {
-            _outputFile->close();
-            delete _outputFile;
-            _outputFile = nullptr;
             _failForWriteError(QStringLiteral("finished"));
             return;
         }
-        _outputFile->close();
-        delete _outputFile;
-        _outputFile = nullptr;
     }
 
     // Check for errors
     if (reply->error() != QNetworkReply::NoError) {
         // Error already handled in _onDownloadError
+        _cleanup();
         if (_state == State::Downloading || _state == State::Verifying) {
             _setState(State::Failed);
             _emitFinished(false, QString(), QGCNetworkHelper::errorMessage(reply));
@@ -281,11 +278,21 @@ void QGCFileDownload::_onDownloadFinished()
             const QString error = tr("HTTP error %1: %2")
                 .arg(statusCode)
                 .arg(QGCNetworkHelper::httpStatusText(statusCode));
+            _cleanup();
             _setErrorString(error);
             _setState(State::Failed);
             _emitFinished(false, QString(), error);
             return;
         }
+    }
+
+    if (_outputFile != nullptr) {
+        if (!_outputFile->commit()) {
+            _failForWriteError(QStringLiteral("commit"));
+            return;
+        }
+        delete _outputFile;
+        _outputFile = nullptr;
     }
 
     qCDebug(QGCFileDownloadLog) << "Download finished:" << _localPath
@@ -429,9 +436,7 @@ void QGCFileDownload::_cleanup()
     }
 
     if (_outputFile != nullptr) {
-        if (_outputFile->isOpen()) {
-            _outputFile->close();
-        }
+        // Destroying an uncommitted QSaveFile discards its temporary.
         delete _outputFile;
         _outputFile = nullptr;
     }
@@ -484,8 +489,10 @@ QString QGCFileDownload::_generateOutputPath(const QString &remoteUrl) const
         return _outputPath;
     }
 
-    // Extract filename from URL
-    QString fileName = QUrl(remoteUrl).fileName();
+    // Extract filename from URL. QUrl::fileName() percent-decodes the segment before
+    // splitting it on '/', so a %5C arrives as a literal '\' and is a directory separator
+    // on Windows. The remote side names the file, never the directory.
+    QString fileName = QFileInfo(QUrl(remoteUrl).fileName()).fileName();
     if (fileName.isEmpty()) {
         fileName = QStringLiteral("DownloadedFile");
     }

--- a/src/Utilities/Network/QGCFileDownload.h
+++ b/src/Utilities/Network/QGCFileDownload.h
@@ -13,7 +13,7 @@
 class QNetworkAccessManager;
 class QAbstractNetworkCache;
 class QGCCompressionJob;
-class QFile;
+class QSaveFile;
 
 /// \brief File download with progress, decompression, and hash verification
 ///
@@ -222,7 +222,7 @@ private:
     QNetworkAccessManager *_networkManager = nullptr;
     QNetworkReply *_currentReply = nullptr;
     QGCCompressionJob *_decompressionJob = nullptr;
-    QFile *_outputFile = nullptr;
+    QSaveFile *_outputFile = nullptr;
 
     QUrl _url;
     QString _localPath;

--- a/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
+++ b/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
@@ -480,6 +480,17 @@ void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, 
         return;
     }
 
+    // This uri comes from the vehicle over an unauthenticated link. QGCFileDownload treats
+    // an unrecognised scheme, and any bare string, as a local file path, so restrict it to
+    // the schemes this state machine actually fetches.
+    if (!_uriIsMAVLinkFTP(uri)
+        && !uri.startsWith(QStringLiteral("http:"), Qt::CaseInsensitive)
+        && !uri.startsWith(QStringLiteral("https:"), Qt::CaseInsensitive)) {
+        qCWarning(RequestMetaDataTypeStateMachineLog) << typeToString() << ": refusing uri with unsupported scheme:" << uri;
+        completeCurrentState();
+        return;
+    }
+
     const QString cachedFile = crcValid ? _compMgr->fileCache().access(cacheFileTag) : "";
 
     if (!cachedFile.isEmpty()) {

--- a/test/Utilities/FileSystem/QGCFileDownloadTest.cc
+++ b/test/Utilities/FileSystem/QGCFileDownloadTest.cc
@@ -5,6 +5,7 @@
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonObject>
 #include <QtCore/QRegularExpression>
+#include <QtCore/QStandardPaths>
 #include <QtTest/QSignalSpy>
 
 #include "QGCCompression.h"
@@ -170,6 +171,82 @@ void QGCFileDownloadTest::_testFileDownloadCancelSingleCompletion()
 
     const QList<QVariant> args = finishedSpy.first();
     QVERIFY(!args.at(0).toBool());
+}
+
+void QGCFileDownloadTest::_testFileDownloadRemoteNameCannotNameTheDirectory()
+{
+    // The remote url is vehicle-supplied on the component-metadata and camera-definition
+    // paths. QUrl::fileName() percent-decodes the last segment before splitting it on '/',
+    // so an encoded separator survives into the derived name. Whatever the url says, the
+    // output has to resolve inside the download directory.
+    const QString downloadDir = QDir::cleanPath(
+        QDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation)).absolutePath());
+
+    const QStringList hostileUrls = {
+        QStringLiteral("file:///nonexistent/a%5C..%5C..%5C..%5CQGCFileDownloadTest_escaped.bin"),
+        QStringLiteral("file:///nonexistent/a%2F..%2F..%2FQGCFileDownloadTest_escaped.bin"),
+        QStringLiteral("file:///nonexistent/C:%5CWindows%5CTemp%5CQGCFileDownloadTest_escaped.bin"),
+        QStringLiteral("file:///nonexistent/..%5C..%5CQGCFileDownloadTest_escaped.bin"),
+    };
+
+    ignoreLogMessage("Utilities.QGCFileDownload", QtWarningMsg, QRegularExpression("Download error:"));
+
+    for (const QString &url : hostileUrls) {
+        QGCFileDownload downloader(this);
+        QVERIFY2(downloader.start(url), qPrintable(url));
+
+        const QString localPath = downloader.localPath();
+        downloader.cancel();
+
+        const QString resolved = QDir::cleanPath(QFileInfo(localPath).absoluteFilePath());
+        QVERIFY2(resolved.startsWith(downloadDir + QLatin1Char('/')), qPrintable(resolved));
+        QVERIFY2(!resolved.mid(downloadDir.length() + 1).contains(QLatin1Char('/')), qPrintable(resolved));
+
+        QFile::remove(localPath);
+    }
+}
+
+void QGCFileDownloadTest::_testFileDownloadFailedDownloadPreservesExistingFile()
+{
+    // The destination must not be created or truncated until the reply is known good.
+    // Opening it up front means a download that 404s, times out, or never reaches a server
+    // still empties whatever was already there.
+    const QString downloadDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+    const QString victimName = QStringLiteral("QGCFileDownloadTest_victim.bin");
+    const QString victimPath = QDir(downloadDir).filePath(victimName);
+    const QByteArray victimContent = QByteArrayLiteral("existing contents that must survive");
+
+    {
+        QFile victim(victimPath);
+        QVERIFY(victim.open(QIODevice::WriteOnly | QIODevice::Truncate));
+        QCOMPARE(victim.write(victimContent), static_cast<qint64>(victimContent.size()));
+    }
+
+    // A source that does not exist, whose last path component is the victim's name, so the
+    // derived output path lands on the victim.
+    QTemporaryDir sourceDir;
+    const QString missingSource = sourceDir.filePath(victimName);
+    QVERIFY(!QFile::exists(missingSource));
+
+    QGCFileDownload downloader(this);
+    QSignalSpy finishedSpy(&downloader, &QGCFileDownload::finished);
+
+    expectLogMessage("Utilities.QGCFileDownload", QtWarningMsg, QRegularExpression("Download error:"));
+    QVERIFY(downloader.start(missingSource));
+    QCOMPARE(QFileInfo(downloader.localPath()).absoluteFilePath(),
+             QFileInfo(victimPath).absoluteFilePath());
+    QVERIFY_SIGNAL_WAIT(finishedSpy, TestTimeout::mediumMs());
+    verifyExpectedLogMessage();
+
+    QCOMPARE(finishedSpy.count(), 1);
+    QVERIFY(!finishedSpy.first().at(0).toBool());
+
+    QFile victim(victimPath);
+    QVERIFY(victim.open(QIODevice::ReadOnly));
+    QCOMPARE(victim.readAll(), victimContent);
+    victim.close();
+
+    QFile::remove(victimPath);
 }
 
 void QGCFileDownloadTest::_testAutoDecompressGzip()

--- a/test/Utilities/FileSystem/QGCFileDownloadTest.h
+++ b/test/Utilities/FileSystem/QGCFileDownloadTest.h
@@ -16,6 +16,8 @@ private slots:
     void _testFileDownloadNonExistentLocalFile();
     void _testFileDownloadOutputPathIsDirectory();
     void _testFileDownloadCancelSingleCompletion();
+    void _testFileDownloadRemoteNameCannotNameTheDirectory();
+    void _testFileDownloadFailedDownloadPreservesExistingFile();
     void _testAutoDecompressGzip();
     void _testAutoDecompressDisabled();
     void _testAutoDecompressUncompressedFile();


### PR DESCRIPTION
## Description

Related to: https://github.com/nicholasaleks/infected-drones/tree/main/QGC-02_component_metadata_uri_ssrf

QGCFileDownload derived the output file name from the remote URL with QUrl::fileName(). That returns the last path segment *percent-decoded*, and the decode happens before the split on '/', so a '%5C' arrives as a literal '\' and is a directory separator on Windows: the write escapes TempLocation entirely. Applying QFileInfo::fileName() reduces it to a plain file name, stripping whatever the host treats as a separator.

The destination was also opened WriteOnly|Truncate before the request was even issued, so a download that 404s, times out, or never reaches a server still destroyed whatever was already at that path. Switching the member to QSaveFile defers that: it writes to a temporary and only replaces the destination on commit(), which now happens once the reply is known good. An uncommitted QSaveFile discards its temporary when destroyed, so the failure paths need nothing beyond the cleanup they already do. QGCFileHelper::atomicWrite() uses the same class for the same reason.

The URLs reaching this code are not trusted: COMPONENT_METADATA.uri, COMPONENT_INFORMATION.general_metadata_uri, the translationUri inside a component-metadata document, and CAMERA_INFORMATION.cam_definition_uri all come straight off an unauthenticated MAVLink link. Two smaller changes follow from that:

  - RequestMetaDataTypeStateMachine::_requestFile() and ComponentInformationTranslation::downloadAndTranslate() now accept only the schemes they actually fetch. QGCFileDownload treats an unrecognised scheme, and any bare string, as a local file path.
  - VehicleCameraControl::_httpRequest() drops QSslSocket::VerifyNone and uses NoLessSafeRedirectPolicy, so a camera-definition URI cannot be silently substituted by an on-path attacker.

Adds two tests: a hostile-name corpus that must resolve inside the download directory, and an existing file that must survive a download that never succeeds. The second fails on the parent commit.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [ ] Windows
- [x] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
- [ ] PX4
- [ ] ArduPilot

## Screenshots
See video in: https://github.com/nicholasaleks/infected-drones/tree/main/QGC-02_component_metadata_uri_ssrf

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
Related to: https://github.com/nicholasaleks/infected-drones/tree/main/QGC-02_component_metadata_uri_ssrf

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
