### PR TITLE
Reduce an explicit MAVLink-FTP download filename to a basename

### DIFF
--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -73,7 +73,10 @@ bool FTPManager::download(uint8_t fromCompId, const QString& fromURI, const QStr
     if (fileName.isEmpty()) {
         _downloadState.fileName = _downloadState.fullPathOnVehicle.right(_downloadState.fullPathOnVehicle.size() - lastDirSlashIndex);
     } else {
-        _downloadState.fileName = fileName;
+        // fileName can originate from the vehicle: a MAVLink-FTP ListDirectory entry is
+        // surfaced to QML and handed straight back here as the local name. Reduce it the
+        // same way the derived branch above already does, so it cannot act as a path.
+        _downloadState.fileName = QFileInfo(fileName).fileName();
     }
 
     qCDebug(FTPManagerLog) << "_downloadState.fullPathOnVehicle:_downloadState.fileName" << _downloadState.fullPathOnVehicle << _downloadState.fileName;

--- a/test/Vehicle/FTPManagerTest.cc
+++ b/test/Vehicle/FTPManagerTest.cc
@@ -1,7 +1,9 @@
 #include "FTPManagerTest.h"
 
+#include <QtCore/QDir>
 #include <QtCore/QFile>
 #include <QtCore/QStandardPaths>
+#include <QtCore/QTemporaryDir>
 #include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
 
@@ -13,6 +15,35 @@
 const FTPManagerTest::TestCase_t FTPManagerTest::_rgTestCases[] = {
     {"/general.json"},
 };
+
+void FTPManagerTest::_testDownloadExplicitFileNameIsBasename()
+{
+    // An explicit fileName can come from the vehicle: a ListDirectory entry is surfaced to
+    // QML and passed straight back as the local name. It must not be usable as a path.
+    _connectMockLinkNoInitialConnectSequence();
+    FTPManager* ftpManager = _vehicle->ftpManager();
+    QSignalSpy spyDownloadComplete(ftpManager, &FTPManager::downloadComplete);
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+
+    ftpManager->download(MAV_COMP_ID_AUTOPILOT1, _rgTestCases[0].file, tempDir.path(),
+                         QStringLiteral("../../QGC03_escaped.bin"));
+    QVERIFY_SIGNAL_WAIT(spyDownloadComplete, TestTimeout::longMs());
+    QCOMPARE(spyDownloadComplete.count(), 1);
+
+    const QList<QVariant> arguments = spyDownloadComplete.takeFirst();
+    QVERIFY2(arguments[1].toString().isEmpty(), qPrintable(arguments[1].toString()));
+
+    const QString downloaded = QDir::cleanPath(QFileInfo(arguments[0].toString()).absoluteFilePath());
+    const QString root = QDir::cleanPath(QDir(tempDir.path()).absolutePath());
+    QVERIFY2(downloaded.startsWith(root + QLatin1Char('/')), qPrintable(downloaded));
+    QCOMPARE(QFileInfo(downloaded).fileName(), QStringLiteral("QGC03_escaped.bin"));
+    QVERIFY(!QFile::exists(QDir(root).filePath(QStringLiteral("../../QGC03_escaped.bin"))));
+
+    QFile::remove(downloaded);
+    _disconnectMockLink();
+}
 
 void FTPManagerTest::cleanup()
 {

--- a/test/Vehicle/FTPManagerTest.h
+++ b/test/Vehicle/FTPManagerTest.h
@@ -23,6 +23,7 @@ private slots:
     void _testListDirectoryBadSequence();
     void _testListDirectoryCancel();
     void _testUpload();
+    void _testDownloadExplicitFileNameIsBasename();
 
     // Overrides from UnitTest
     void cleanup() override;


### PR DESCRIPTION
## Description

Related to: https://github.com/nicholasaleks/infected-drones/tree/main/QGC-03_ftp_download_write_and_offset

FTPManager::download() takes an optional local fileName. When it is empty the name is derived from the remote URI by taking everything after the last '/', which reduces it to a basename. When a caller supplies one it was used verbatim, and the sink builds the path with QDir::filePath(), which does not collapse "..".

That caller can be the vehicle. ScriptingComponent.qml lists /APM/scripts/ over MAVLink-FTP, strips only the type byte and the "\t<size>" suffix from each entry, and passes the result back as the local fileName, so a listing entry named "../../../../tmp/EVIL.lua" writes outside the folder the operator chose. The page already has a basename helper and applies it on the upload path, just not here.

Applying QFileInfo::fileName() in the explicit branch makes it behave like the derived one. It strips whatever the host treats as a separator, which is the same rule the rest of the path handling follows.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [ ] Windows
- [x] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
- [ ] PX4
- [ ] ArduPilot

## Screenshots
Video in https://github.com/nicholasaleks/infected-drones/tree/main/QGC-03_ftp_download_write_and_offset

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
Related to https://github.com/nicholasaleks/infected-drones/tree/main/QGC-03_ftp_download_write_and_offset

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
