### PR TITLE
Reject DataFlash FMT records whose length and format disagree

### DIFF
--- a/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.cc
+++ b/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.cc
@@ -252,7 +252,14 @@ bool parseFmtMessages(const char *data, qint64 size, QMap<uint8_t, MessageFormat
             }
 
             const MessageFormat fmt = parseFmtPayload(data + pos);
-            formats[fmt.type] = fmt;
+            // length and format come from the log and describe the same record, so they
+            // have to agree: length counts the 3-byte header, and the fields the format
+            // string declares must fit in what is left. Checking it here is what keeps
+            // "length - 3" non-negative below and in iterateMessages(), and what bounds
+            // the offset parseMessage() accumulates from the format string.
+            if ((fmt.length >= 3) && (calculatePayloadSize(fmt.format) <= (fmt.length - 3))) {
+                formats[fmt.type] = fmt;
+            }
             pos += kFmtPayloadSize;
         } else {
             // Skip message if we know its length

--- a/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.cc
+++ b/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.cc
@@ -310,6 +310,54 @@ void APMDataFlashUtilityTest::_testParseFmtMessages()
     QCOMPARE(formats[128].name, QStringLiteral("FMT"));
 }
 
+void APMDataFlashUtilityTest::_testParseFmtMessagesRejectsInconsistentLength()
+{
+    // length and format are both read from the log. A format may only be registered when
+    // they agree, because "length - 3" is used as a payload size elsewhere and the format
+    // string drives how many bytes parseMessage() reads.
+    auto fmtRecord = [](uint8_t type, uint8_t length, const char *format) {
+        QByteArray record;
+        record.append(static_cast<char>(0xA3));
+        record.append(static_cast<char>(0x95));
+        record.append(static_cast<char>(128));
+        char payload[86];
+        memset(payload, 0, sizeof(payload));
+        payload[0] = static_cast<char>(type);
+        payload[1] = static_cast<char>(length);
+        memcpy(payload + 2, "TST\0", 4);
+        memcpy(payload + 6, format, qMin(strlen(format), static_cast<size_t>(16)));
+        memcpy(payload + 22, "A,B,C", 5);
+        record.append(payload, sizeof(payload));
+        return record;
+    };
+
+    // length < 3 makes "length - 3" negative. With a record of that type following, the
+    // cursor stops advancing and the scan never terminates.
+    for (uint8_t badLength : {uint8_t(0), uint8_t(1), uint8_t(2)}) {
+        const QByteArray data = fmtRecord(100, badLength, "BB") + QByteArray("\xA3\x95\x64ABCD", 7);
+        QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+        APMDataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats);
+        QVERIFY2(!formats.contains(100), qPrintable(QStringLiteral("length %1 was registered").arg(badLength)));
+    }
+
+    // A format declaring more bytes than the record holds would make parseMessage() read
+    // past the payload: length 4 leaves one byte, "a" asks for 64.
+    {
+        const QByteArray data = fmtRecord(101, 4, "a");
+        QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+        APMDataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats);
+        QVERIFY(!formats.contains(101));
+    }
+
+    // A consistent record is still accepted: "QBb" is 8 + 1 + 1, so length 13.
+    {
+        const QByteArray data = fmtRecord(102, 13, "QBb");
+        QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+        QVERIFY(APMDataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
+        QVERIFY(formats.contains(102));
+    }
+}
+
 // ============================================================================
 // Message Parsing Tests
 // ============================================================================

--- a/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.h
+++ b/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.h
@@ -33,6 +33,7 @@ private slots:
     // FMT message parsing tests
     void _testParseFmtPayload();
     void _testParseFmtMessages();
+    void _testParseFmtMessagesRejectsInconsistentLength();
 
     // Message parsing tests
     void _testParseMessage();


### PR DESCRIPTION
## Description

Related to: https://github.com/nicholasaleks/infected-drones/tree/main/QGC-04_dataflash_bin_parser_oob

Every FMT record in a .bin log carries both a length and a format string, and the parser trusts each of them separately without ever comparing the two.

length is a uint8_t read from the log. Both parser passes compute "fmt.length - 3" to get a payload size, and integer promotion makes that a negative int for length < 3. The bounds check in iterateMessages(), "pos + payloadSize > size", is meant to catch an over-long payload; a negative value makes the left side smaller, so it never fires. The cursor then moves backward by that amount. Both loops consume the 3-byte header with pos += 3 first, so length == 0 is exactly net zero movement and the same record is re-parsed forever. That hangs parseFmtMessages() during the initial format scan, before a single message is iterated: opening such a log pins a core at 100% with no error reported.

Independently, parseMessage() walks the format string and accumulates an offset from formatCharSize() alone, up to 64 bytes for 'a' or 'Z'. It is not given the payload length and has nothing to check against, so a format declaring more bytes than the record holds reads past the end of it. The buffer is a memory-mapped file, so that read either lands in the zero-filled tail of the last page or faults.

Both follow from the same thing: the two sizes are never reconciled. They are first known together at registration, so check them there. A format is registered only when length leaves room for a header and the fields the format string declares fit inside the remaining payload. That keeps "length - 3" non-negative everywhere it is used and bounds the offset parseMessage() accumulates, without changing its signature or its call sites.

Adds a test covering length 0, 1 and 2, a format wider than the declared payload, and a consistent record that must still be accepted.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [ ] Windows
- [x] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
- [ ] PX4
- [ ] ArduPilot

## Screenshots
Video in https://github.com/nicholasaleks/infected-drones/tree/main/QGC-04_dataflash_bin_parser_oob

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
https://github.com/nicholasaleks/infected-drones/tree/main/QGC-04_dataflash_bin_parser_oob

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
