### PR TITLE
APM: add LSM6DSK320X and ICM56686 IMU device names

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorIdDecoder.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorIdDecoder.qml
@@ -84,7 +84,14 @@ QGCLabel {
         0x3A: 'INS_ICM42670',
         0x3B: 'INS_ICM45686',
         0x3C: 'INS_SCHA63T',
-        0x3D: 'INS_IIM42653'
+        0x3D: 'INS_IIM42653',
+        0x3E: 'INS_LSM6DSV16X',
+        0x3F: 'INS_ASM330',
+        0x40: 'INS_ADIS16607',
+        0x41: 'INS_ZEROONE_FPGA_SCH16T',
+        0x42: 'INS_LSM6DSV32X',
+        0x43: 'INS_LSM6DSK320X',
+        0x44: 'INS_ICM56686'
     }
 
     property var baroTypes: {


### PR DESCRIPTION
Description
-----------
ArduPilot already reports IMU device types `DEVTYPE_INS_LSM6DSK320X` (`0x43`) and `DEVTYPE_INS_ICM56686` (`0x44`), but `APMSensorIdDecoder.qml` does not map them, so the Sensors / Hardware ID UI shows `?`.

This adds those two names, and also the other IMU types added in ArduPilot since `IIM42653`:

| ID | Name |
| --- | --- |
| `0x3E` | LSM6DSV16X |
| `0x3F` | ASM330 |
| `0x40` | ADIS16607 |
| `0x41` | ZEROONE_FPGA_SCH16T |
| `0x42` | LSM6DSV32X |
| `0x43` | LSM6DSK320X |
| `0x44` | ICM56686 |

Source of IDs: [AP_InertialSensor_Backend.h](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h)

Related ArduPilot PRs:
- https://github.com/ArduPilot/ardupilot/pull/33293 (LSM6DSV32X / LSM6DSK320X)
- https://github.com/ArduPilot/ardupilot/pull/33991 (ICM-56686)

Test Steps
-----------
1. Connect an ArduPilot vehicle whose `INS_ACC_ID` / `INS_GYR_ID` uses one of the new device types (especially LSM6DSK320X or ICM56686).
2. Open Vehicle Setup → Sensors (or any APM page that shows `APMSensorIdDecoder`).
3. Confirm the IMU name is shown instead of `?`.

Testing
-------
Confirmed on an Accton Godwit GA1 rework board with ICM-56686 and LSM6DSK320X. ArduPilot reports the correct `DEVTYPE` IDs for both IMUs. Current QGroundControl shows `?` for them.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

This contribution was AI-assisted. The device IDs were taken from ArduPilot source, not invented.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.