### PR TITLE
fix(Settings): show sidebar group dividers and hide dangling ones (Stable_V5.1)

### DIFF
--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -56,6 +56,36 @@ Rectangle {
         return false
     }
 
+    // A divider shows only between two available pages. When consecutive dividers have no
+    // available page between them, only the first one shows.
+    function _dividerVisible(pageIndex) {
+        if (_searchQuery.trim() !== "") {
+            return false
+        }
+
+        let hasPageBefore = false
+        for (let i = pageIndex - 1; i >= 0; i--) {
+            let entry = settingsPagesModel.get(i)
+            if (entry.name === "Divider") {
+                return false
+            }
+            if (_pageAvailable(entry)) {
+                hasPageBefore = true
+                break
+            }
+        }
+        if (!hasPageBefore) {
+            return false
+        }
+
+        for (let j = pageIndex + 1; j < settingsPagesModel.count; j++) {
+            if (_pageAvailable(settingsPagesModel.get(j))) {
+                return true
+            }
+        }
+        return false
+    }
+
     // Search: returns array of matching section indices for a page, or empty if no match
     function _matchingSections(pageIndex) {
         var query = _searchQuery.toLowerCase().trim()
@@ -246,17 +276,15 @@ Rectangle {
                     }
 
                     visible: {
-                        if (pageName === "Divider") return !isSearching
+                        if (pageName === "Divider") return settingsView._dividerVisible(index)
                         if (!pageAvailable) return false
                         if (isSearching) return matchesSearch
                         return true
                     }
 
-                    // Divider
-                    Item {
-                        Layout.fillWidth: true
-                        height: ScreenTools.defaultFontPixelHeight / 2
-                        visible: pageName === "Divider"
+                    SidebarDivider {
+                        objectName: pageName === "Divider" ? "settingsDivider_" + index : ""
+                        visible:    pageName === "Divider"
                     }
 
                     // Page button

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -174,6 +174,7 @@ qt_add_qml_module(QGroundControlControlsModule
         SettingsButton.qml
         SettingsGroupLayout.qml
         SetupPage.qml
+        SidebarDivider.qml
         SliderSwitch.qml
         SubMenuButton.qml
         TimedProgressTracker.qml

--- a/src/QmlControls/SidebarDivider.qml
+++ b/src/QmlControls/SidebarDivider.qml
@@ -1,0 +1,21 @@
+import QtQuick
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Horizontal separator between groups in a sidebar navigation list
+Item {
+    Layout.fillWidth:       true
+    Layout.preferredHeight: ScreenTools.defaultFontPixelHeight / 2
+
+    QGCPalette { id: qgcPal }
+
+    Rectangle {
+        anchors.left:           parent.left
+        anchors.right:          parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        height:                 1
+        color:                  qgcPal.windowShade
+    }
+}

--- a/src/Vehicle/VehicleSetup/VehicleConfigView.qml
+++ b/src/Vehicle/VehicleSetup/VehicleConfigView.qml
@@ -129,6 +129,20 @@ Rectangle {
         return false
     }
 
+    function _componentVisible(component) {
+        if (!component || component.setupSource.toString() === "") {
+            return false
+        }
+        return _searchQuery.trim() === "" || _componentMatchesSearch(component)
+    }
+
+    function _anyComponentVisible() {
+        if (!_fullParameterVehicleAvailable) {
+            return false
+        }
+        return _activeVehicle.autopilotPlugin.vehicleComponents.some(_componentVisible)
+    }
+
     function showSummaryPanel() {
         if (mainWindow.allowViewSwitch()) {
             _showSummaryPanel()
@@ -344,6 +358,7 @@ Rectangle {
 
         QGCTextField {
             id:                 searchField
+            objectName:         "vehicleConfig_searchField"
             Layout.fillWidth:   true
             placeholderText:    qsTr("Search configuration...")
             visible:            _fullParameterVehicleAvailable
@@ -379,10 +394,12 @@ Rectangle {
                     onClicked: showSummaryPanel()
                 }
 
-                Item {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: ScreenTools.defaultFontPixelHeight / 2
-                    visible: vehicleConfigView._searchQuery.trim() === ""
+                // When the component group is empty only this divider shows, not the second one
+                SidebarDivider {
+                    objectName: "vehicleConfig_summaryDivider"
+                    visible:    summaryButton.visible &&
+                                (vehicleConfigView._anyComponentVisible() || opticalFlowButton.visible ||
+                                 parametersButton.visible || firmwareButton.visible)
                 }
 
                 // Vehicle component tree
@@ -407,12 +424,7 @@ Rectangle {
                         property bool   matchesSearch:  comp ? vehicleConfigView._componentMatchesSearch(comp) : false
                         property bool   isExpanded:     hasSections && (isSearching ? matchesSearch : vehicleConfigView._isExpanded(index))
 
-                        visible: {
-                            if (!comp) return false
-                            if (comp.setupSource.toString() === "") return false
-                            if (isSearching) return matchesSearch
-                            return true
-                        }
+                        visible: vehicleConfigView._componentVisible(comp)
 
                         ConfigButton {
                             Layout.fillWidth:   true
@@ -520,6 +532,7 @@ Rectangle {
 
                 // Optical Flow (special)
                 ConfigButton {
+                    id:                 opticalFlowButton
                     visible:            _activeVehicle ? _activeVehicle.flowImageIndex > 0 : false
                     text:               qsTr("Optical Flow")
                     Layout.fillWidth:   true
@@ -527,10 +540,10 @@ Rectangle {
                     onClicked:          showPanel("opticalflow", "qrc:/qml/QGroundControl/VehicleSetup/OpticalFlowSensor.qml")
                 }
 
-                Item {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: ScreenTools.defaultFontPixelHeight / 2
-                    visible: vehicleConfigView._searchQuery.trim() === ""
+                SidebarDivider {
+                    objectName: "vehicleConfig_componentsDivider"
+                    visible:    (vehicleConfigView._anyComponentVisible() || opticalFlowButton.visible) &&
+                                (parametersButton.visible || firmwareButton.visible)
                 }
 
                 ConfigButton {
@@ -549,6 +562,7 @@ Rectangle {
 
                 ConfigButton {
                     id:                 firmwareButton
+                    objectName:         "vehicleConfig_firmwareButton"
                     icon.source:        "/qmlimages/FirmwareUpgradeIcon.png"
                     visible:            !ScreenTools.isMobile && _corePlugin.options.showFirmwareUpgrade &&
                                         vehicleConfigView._searchQuery.trim() === ""

--- a/test/QmlUITests/PX4VehicleConfigUITest.cc
+++ b/test/QmlUITests/PX4VehicleConfigUITest.cc
@@ -33,6 +33,35 @@ void PX4VehicleConfigUITest::_testNavigateVehicleConfig()
     });
 }
 
+// With a full-parameter vehicle both dividers show; searching flattens the sidebar and hides them.
+void PX4VehicleConfigUITest::_testSidebarDividers()
+{
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(); },
+        [&](QPointer<MockLink> /*mockLink*/, Vehicle * /*vehicle*/) {
+    navigateToConfigureView();
+    if (QTest::currentTestFailed()) return;
+
+    QQuickItem *const summaryDivider = findItem(_rootItem, QStringLiteral("vehicleConfig_summaryDivider"));
+    QQuickItem *const componentsDivider = findItem(_rootItem, QStringLiteral("vehicleConfig_componentsDivider"));
+    QVERIFY(summaryDivider);
+    QVERIFY(componentsDivider);
+    QTRY_VERIFY(summaryDivider->isVisible());
+    QTRY_VERIFY(componentsDivider->isVisible());
+
+    QQuickItem *const searchField = findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_searchField"), 3000);
+    QVERIFY(searchField);
+    searchField->setProperty("text", QStringLiteral("sensors"));
+    QTRY_VERIFY(!summaryDivider->isVisible());
+    QTRY_VERIFY(!componentsDivider->isVisible());
+
+    searchField->setProperty("text", QString());
+    QTRY_VERIFY(summaryDivider->isVisible());
+    QTRY_VERIFY(componentsDivider->isVisible());
+
+    });
+}
+
 // Cycle through the axis buttons on a PID tuning tab. Each click exercises
 // the LineSeries remove/re-add path on GraphsView; qWait lets the polish pass run.
 void PX4VehicleConfigUITest::_cycleAxisButtons(const QStringList &axisNames)

--- a/test/QmlUITests/PX4VehicleConfigUITest.h
+++ b/test/QmlUITests/PX4VehicleConfigUITest.h
@@ -16,6 +16,7 @@ public:
 private slots:
     void _testNavigateVehicleConfig();
     void _testDisconnectWithPIDTuningOpen();
+    void _testSidebarDividers();
 
 private:
     /// Click each axis button in \a axisNames in order, waiting for a polish

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -49,6 +49,23 @@ static QQuickItem *findVisibleItemImmediate(QQuickItem *root, const QString &obj
     return nullptr;
 }
 
+QQuickItem *QmlUITestBase::findItem(QQuickItem *root, const QString &objectName)
+{
+    if (!root) {
+        return nullptr;
+    }
+    if (root->objectName() == objectName) {
+        return root;
+    }
+    const auto children = root->childItems();
+    for (auto *child : children) {
+        if (auto *found = findItem(child, objectName)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
+
 QQuickItem *QmlUITestBase::findVisibleItem(QQuickItem *root, const QString &objectName, int timeoutMs)
 {
     constexpr int pollIntervalMs = 50;

--- a/test/QmlUITests/QmlUITestBase.h
+++ b/test/QmlUITests/QmlUITestBase.h
@@ -70,6 +70,10 @@ protected:
     /// failure stays in the offending test.
     void _verifyFileDialogTestHookConsumed();
 
+    /// Finds a QQuickItem by objectName in the visual tree regardless of visibility.
+    /// Use when asserting that an item is hidden. Returns nullptr if not found.
+    static QQuickItem *findItem(QQuickItem *root, const QString &objectName);
+
     /// Finds a visible QQuickItem by objectName in the visual tree, polling with
     /// 50ms intervals up to timeoutMs. Returns nullptr if not found within the timeout.
     static QQuickItem *findVisibleItem(QQuickItem *root, const QString &objectName, int timeoutMs = 1000);

--- a/test/QmlUITests/TopLevelViewsTest.cc
+++ b/test/QmlUITests/TopLevelViewsTest.cc
@@ -4,7 +4,10 @@
 #include <QtQuick/QQuickItem>
 #include <QtTest/QTest>
 
+#include <algorithm>
+
 #include "Fact.h"
+#include "ScreenToolsController.h"
 #include "SettingsManager.h"
 #include "VideoSettings.h"
 
@@ -39,6 +42,31 @@ static QQuickItem* findVisibleSectionButton(QQuickItem* root, const QString& sec
 static void setVideoSource(const char* source)
 {
     SettingsManager::instance()->videoSettings()->videoSource()->setRawValue(QString::fromLatin1(source));
+}
+
+static void collectSettingsDividers(QQuickItem* item, QList<QQuickItem*>& dividers)
+{
+    if (!item) {
+        return;
+    }
+    if (item->objectName().startsWith(QStringLiteral("settingsDivider_"))) {
+        dividers.append(item);
+    }
+    const auto children = item->childItems();
+    for (auto* child : children) {
+        collectSettingsDividers(child, dividers);
+    }
+}
+
+// Settings sidebar dividers are named settingsDivider_<modelIndex>; returns them in model order
+static QList<QQuickItem*> findSettingsDividers(QQuickItem* root)
+{
+    QList<QQuickItem*> dividers;
+    collectSettingsDividers(root, dividers);
+    std::sort(dividers.begin(), dividers.end(), [](const QQuickItem* a, const QQuickItem* b) {
+        return a->objectName().section('_', 1).toInt() < b->objectName().section('_', 1).toInt();
+    });
+    return dividers;
 }
 
 // Sets the video source and returns a guard restoring the original value on scope exit
@@ -288,4 +316,63 @@ void TopLevelViewsTest::_testSettingsSearchExcludesHiddenSections()
     // not because the page became unavailable: clearing the search brings it back
     searchField->setProperty("text", QString());
     QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsButton_Video"), 0));
+}
+
+// A divider only shows between two groups that both contain an available page. The
+// trailing divider precedes the debug-only pages, so it must hide in release builds.
+void TopLevelViewsTest::_testSettingsDividerVisibility()
+{
+    startUI();
+    if (QTest::currentTestFailed())
+        return;
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewSettings")));
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settings_buttonList")));
+
+    // SettingsPages.json: dividers after Plan View, after 3D View, after Help
+    const QList<QQuickItem*> dividers = findSettingsDividers(_rootItem);
+    QCOMPARE(dividers.size(), 3);
+    QTRY_VERIFY(dividers[0]->isVisible());
+    QTRY_VERIFY(dividers[1]->isVisible());
+    QTRY_COMPARE(dividers[2]->isVisible(), ScreenToolsController::isDebug());
+
+    // Search flattens the list into matches only
+    QQuickItem* const searchField = findVisibleItem(_rootItem, QStringLiteral("settings_searchField"));
+    QVERIFY(searchField);
+    searchField->setProperty("text", QStringLiteral("video"));
+    for (QQuickItem* divider : dividers) {
+        QTRY_VERIFY(!divider->isVisible());
+    }
+
+    searchField->setProperty("text", QString());
+    QTRY_VERIFY(dividers[0]->isVisible());
+    QTRY_VERIFY(dividers[1]->isVisible());
+    QTRY_COMPARE(dividers[2]->isVisible(), ScreenToolsController::isDebug());
+}
+
+// With no vehicle the component group is empty and Parameters is hidden: the divider
+// after Summary shows only because Firmware follows it, and the one before
+// Parameters/Firmware must not leave a dangling gap.
+void TopLevelViewsTest::_testVehicleConfigDividersNoVehicle()
+{
+    startUI();
+    if (QTest::currentTestFailed())
+        return;
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewConfigure")));
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_root"), 3000));
+
+    QQuickItem* const parametersButton = findItem(_rootItem, QStringLiteral("vehicleConfig_parametersButton"));
+    QQuickItem* const firmwareButton = findItem(_rootItem, QStringLiteral("vehicleConfig_firmwareButton"));
+    QQuickItem* const summaryDivider = findItem(_rootItem, QStringLiteral("vehicleConfig_summaryDivider"));
+    QQuickItem* const componentsDivider = findItem(_rootItem, QStringLiteral("vehicleConfig_componentsDivider"));
+    QVERIFY(parametersButton);
+    QVERIFY(firmwareButton);
+    QVERIFY(summaryDivider);
+    QVERIFY(componentsDivider);
+
+    QTRY_VERIFY(!parametersButton->isVisible());
+    QTRY_VERIFY(firmwareButton->isVisible());
+    QTRY_VERIFY(summaryDivider->isVisible());
+    QTRY_VERIFY(!componentsDivider->isVisible());
 }

--- a/test/QmlUITests/TopLevelViewsTest.h
+++ b/test/QmlUITests/TopLevelViewsTest.h
@@ -21,6 +21,8 @@ private slots:
     void _testSettingsSectionCollapseToSingle();
     void _testSettingsPageUnavailableFallback();
     void _testSettingsSearchExcludesHiddenSections();
+    void _testSettingsDividerVisibility();
+    void _testVehicleConfigDividersNoVehicle();
 
 private:
     QQuickItem* _clickSettingsButton(const QString& pageName);


### PR DESCRIPTION
Cherry-pick of #15089 to Stable_V5.1.

## Description

Adds a visible 1px divider line between groups in the App Settings and Vehicle Config sidebars, using a new shared `SidebarDivider` control. Dividers now only render between two visible groups, fixing:

- App Settings: a dangling divider after Help in release builds (the debug-only pages below it are hidden).
- Vehicle Config: a doubled gap when no vehicle is connected (the component group between the two spacers is empty).

Dividers remain hidden while searching in both views.

Only conflict was pointer-style formatting in `QmlUITestBase.cc/.h`; resolved to match the stable branch style.

## Type of Change

Bug fix (non-breaking change that fixes an issue)

## Testing

Built locally on Stable_V5.1 and ran TopLevelViewsTest, PX4VehicleConfigUITest, APMVehicleConfigUITest — all pass.

### Platforms Tested

macOS

By submitting this pull request, I confirm that my contribution is made under
the terms of the project's dual license (Apache 2.0 and GPL v3).