### PR TITLE
fix(AnalyzeView): complete 0 byte onboard logs instead of stalling the download

### DIFF
--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -417,13 +417,23 @@ bool OnboardLogController::_logComplete() const
 void OnboardLogController::_receivedAllData()
 {
     _timer->stop();
-    if (_prepareLogDownload()) {
+    while (_prepareLogDownload()) {
+        if (_downloadData->chunk_table.isEmpty()) {
+            // Nothing to request (0 byte log): _logComplete() can never become true and the
+            // vehicle never answers a zero-length request, so the download would stall
+            // forever (issue #15068). The empty file already exists.
+            _downloadData->entry->setStatus(tr("Downloaded"));
+            _downloadData.reset();
+            continue;
+        }
+
         _requestLogData(_downloadData->ID, 0, _downloadData->chunk_table.size() * MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN);
         _timer->start(kTimeOutMs);
-    } else {
-        _resetSelection();
-        _setDownloading(false);
+        return;
     }
+
+    _resetSelection();
+    _setDownloading(false);
 }
 
 bool OnboardLogController::_prepareLogDownload()

--- a/test/AnalyzeView/OnboardLogDownloadTest.cc
+++ b/test/AnalyzeView/OnboardLogDownloadTest.cc
@@ -1,6 +1,7 @@
 #include "OnboardLogDownloadTest.h"
 
 #include <QtCore/QDir>
+#include <QtCore/QFileInfo>
 #include <QtCore/QTemporaryDir>
 #include <QtCore/QTimeZone>
 #include <QtCore/QTimer>
@@ -350,6 +351,81 @@ void OnboardLogFtpDownloadTest::_ftpListNoTimeFallbackTest()
     QFile file(QDir(tempDir.path()).filePath(downloadedFiles.first()));
     QVERIFY(file.open(QIODevice::ReadOnly));
     QCOMPARE(file.readAll(), _mockLink->mockLinkFTP()->logFileContents(QStringLiteral("log_2.ulg")));
+}
+
+void OnboardLogFtpDownloadTest::_messagesZeroByteLogTest()
+{
+    _connectMockLink(MAV_AUTOPILOT_PX4, MockConfiguration::FailNone, MockConfiguration::OptionFtpCapability);
+    if (QTest::currentTestFailed()) return;
+
+    // A 0 byte log has nothing to request over the message transport, so it must be
+    // completed immediately and not stall the rest of the queue (issue #15068).
+    const QList<MockLinkFTP::LogFile> logFiles = {
+        { QStringLiteral("log_1.ulg"), 5000, 1700000000 },
+        { QStringLiteral("log_2.ulg"), 0,    1700086400 },
+        { QStringLiteral("log_3.ulg"), 3000, 1700172800 },
+    };
+    _mockLink->mockLinkFTP()->setLogFiles(logFiles);
+    _mockLink->mockLinkFTP()->setListDirectoryWithTimeSupported(false);
+
+    OnboardLogController* const controller = new OnboardLogController(this);
+    MultiSignalSpy* multiSpy = new MultiSignalSpy(this);
+    QVERIFY(multiSpy->init(controller));
+
+    QVERIFY(refreshAndWaitForListComplete(controller, multiSpy));
+    QCOMPARE(controller->transport(), QStringLiteral("messages"));
+
+    QmlObjectListModel* const model = controller->_getModel();
+    QVERIFY(model);
+    QCOMPARE(model->count(), 3);
+
+    QGCOnboardLogEntry* zeroByteEntry = nullptr;
+    for (int i = 0; i < model->count(); i++) {
+        QGCOnboardLogEntry* const entry = model->value<QGCOnboardLogEntry*>(i);
+        QVERIFY(entry);
+        if (entry->size() == 0) {
+            zeroByteEntry = entry;
+        }
+    }
+    QVERIFY(zeroByteEntry);
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QDir downloadDir(tempDir.path());
+
+    // Only the 0 byte log selected: the whole download cycle completes synchronously inside download()
+    zeroByteEntry->setSelected(true);
+    QVERIFY(downloadAndWaitForComplete(controller, multiSpy, tempDir.path()));
+    QCOMPARE(zeroByteEntry->status(), QStringLiteral("Downloaded"));
+    QCOMPARE(controller->selectedCount(), 0);
+    const QStringList zeroByteFiles =
+        downloadDir.entryList({ QStringLiteral("log_%1_*").arg(zeroByteEntry->id()) }, QDir::Files);
+    QCOMPARE(zeroByteFiles.count(), 1);
+    QCOMPARE(QFileInfo(downloadDir.filePath(zeroByteFiles.first())).size(), qint64(0));
+    QVERIFY(QFile::remove(downloadDir.filePath(zeroByteFiles.first())));
+
+    // 0 byte log in the middle of a multi-select must not stall the rest of the queue
+    controller->selectAll(true);
+    QVERIFY(downloadAndWaitForComplete(controller, multiSpy, tempDir.path()));
+
+    QCOMPARE(controller->selectedCount(), 0);
+
+    // Every entry completed and its file holds the exact per-id contents, including an
+    // empty file for the 0 byte log. Filenames embed the local-time formatted log date so
+    // match each entry's file by its "log_<id>_" prefix.
+    QCOMPARE(downloadDir.entryList(QDir::Files).count(), 3);
+    for (int i = 0; i < model->count(); i++) {
+        const QGCOnboardLogEntry* const entry = model->value<const QGCOnboardLogEntry*>(i);
+        QVERIFY(entry);
+        QCOMPARE(entry->status(), QStringLiteral("Downloaded"));
+
+        const QStringList matches =
+            downloadDir.entryList({ QStringLiteral("log_%1_*").arg(entry->id()) }, QDir::Files);
+        QCOMPARE(matches.count(), 1);
+        QFile file(downloadDir.filePath(matches.first()));
+        QVERIFY2(file.open(QIODevice::ReadOnly), qPrintable(matches.first()));
+        QCOMPARE(file.readAll(), _mockLink->mockLinkFTP()->logFileContents(logFiles[entry->id()].name));
+    }
 }
 
 void OnboardLogFtpDownloadTest::_ftpCancelListNoFallbackTest()

--- a/test/AnalyzeView/OnboardLogDownloadTest.h
+++ b/test/AnalyzeView/OnboardLogDownloadTest.h
@@ -28,6 +28,7 @@ class OnboardLogFtpDownloadTest : public VehicleTestManualConnect
 private slots:
     void _ftpListAndDownloadTest();
     void _ftpListNoTimeFallbackTest();
+    void _messagesZeroByteLogTest();
     void _ftpCancelListNoFallbackTest();
     void _ftpListFallbackTest();
     void _ftpMultiDownloadAndDedupTest();


### PR DESCRIPTION
Fixes #15068

## Description

Downloading a 0 byte onboard log over the message based (LOG_REQUEST_DATA) transport stalled forever at `(0B/s)`, blocking any logs queued after it.

Root cause: a 0 byte entry produces an empty `chunk_table`, so `_chunkComplete()` is trivially true but `_logComplete()` can never become true (`current_chunk + 1 == numChunks()` is `1 == 0`). Each timeout then called `advanceChunk()`, underflowed `chunkBins()` and re-requested a bogus range with no retry cap.

`_receivedAllData()` now completes zero-length entries immediately (status "Downloaded", empty file kept — matching the FTP transport) and continues with the next selected log.

## Type of Change

Bug fix (non-breaking change that fixes an issue)

## Testing

New `OnboardLogFtpDownloadTest::_messagesZeroByteLogTest` covers both repros from the issue on the message transport: selecting only the 0 byte log, and a 0 byte log in the middle of a multi-select. It verifies every entry reports Downloaded and each output file matches the mock's per-id contents (empty file for the 0 byte log). Confirmed the test fails without the fix (stalls with repeated past-EOF requests) and passes with it.

`OnboardLogDownloadTest` and `OnboardLogFtpDownloadTest` pass locally.

### Platforms Tested

macOS

By submitting this pull request, I confirm that my contribution is made under
the terms of the project's dual license (Apache 2.0 and GPL v3).