### PR TITLE
test(Vehicle): use production ack timeout in tests unless ack is never expected

### DIFF
--- a/src/Vehicle/MavCommandQueue.cc
+++ b/src/Vehicle/MavCommandQueue.cc
@@ -17,6 +17,8 @@
 
 QGC_LOGGING_CATEGORY(MavCommandQueueLog, "Vehicle.MavCommandQueue")
 
+std::optional<int> MavCommandQueue::_testAckTimeoutOverride;
+
 MavCommandQueue::MavCommandQueue(Vehicle* vehicle)
     : QObject(vehicle)
     , _vehicle(vehicle)
@@ -193,8 +195,25 @@ int MavCommandQueue::_responseCheckIntervalMSecs()
 
 int MavCommandQueue::_ackTimeoutMSecs()
 {
-    // Use shorter ack timeout during unit tests for faster test execution
-    return QGC::runningUnitTests() ? kTestAckTimeoutMs : 1200;
+    return _testAckTimeoutOverride.value_or(_ackTimeoutMSecsDefault);
+}
+
+void MavCommandQueue::setTestAckTimeoutOverride(std::optional<int> msecs)
+{
+    if (!QGC::runningUnitTests()) {
+        qCWarning(MavCommandQueueLog) << "setTestAckTimeoutOverride called outside unit tests, ignoring";
+        return;
+    }
+    if (msecs.has_value() && *msecs <= 0) {
+        qCWarning(MavCommandQueueLog) << "setTestAckTimeoutOverride rejecting non-positive timeout:" << *msecs;
+        return;
+    }
+    _testAckTimeoutOverride = msecs;
+}
+
+std::optional<int> MavCommandQueue::testAckTimeoutOverride()
+{
+    return _testAckTimeoutOverride;
 }
 
 bool MavCommandQueue::_shouldRetry(MAV_CMD command)

--- a/src/Vehicle/MavCommandQueue.h
+++ b/src/Vehicle/MavCommandQueue.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QList>
@@ -60,10 +61,13 @@ public:
     static QString failureCodeToString(MavCmdResultFailureCode_t failureCode);
     static void showCommandAckError(const mavlink_command_ack_t& ack);
 
-    // Test tuning knobs.
-    static constexpr int kTestAckTimeoutMs = 500;
     static constexpr int kMaxRetryCount = 3;
-    static constexpr int kTestMaxWaitMs = kTestAckTimeoutMs * kMaxRetryCount * 2;
+
+    /// Test-only: shorten the ack timeout for tests whose outcome depends on at least one ack window
+    /// expiring (no ack, or ack only after a retry). Tests where every command is acked on first send
+    /// must leave this unset so they run against the production timeout.
+    static void setTestAckTimeoutOverride(std::optional<int> msecs);
+    static std::optional<int> testAckTimeoutOverride();
 
 signals:
     /// Emitted for every terminal ack that has no user-provided resultHandler.
@@ -107,5 +111,7 @@ private:
     QTimer                           _responseCheckTimer;
     bool                             _stopped = false;  // set by stop(), gates all send paths
 
+    static constexpr int _ackTimeoutMSecsDefault     = 1200;
     static constexpr int _ackTimeoutMSecsHighLatency = 120000;
+    static std::optional<int>        _testAckTimeoutOverride;
 };

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1057,12 +1057,6 @@ private:
     RequestMessageCoordinator*  _reqMsgCoord    = nullptr;
 
 public:
-    /// Ack timeout used in unit tests — kept on Vehicle for source-compat with
-    /// existing tests (mirrors MavCommandQueue::kTestAckTimeoutMs).
-    static constexpr int _mavCommandMaxRetryCount    = 3;
-    static constexpr int kTestMavCommandAckTimeoutMs = 500;
-    static constexpr int kTestMavCommandMaxWaitMs    = kTestMavCommandAckTimeoutMs * _mavCommandMaxRetryCount * 2;
-
     /// Test-only helper: forwards to MavCommandQueue::findEntryIndex.
     int  _findMavCommandListEntryIndex(int targetCompId, MAV_CMD command);
 

--- a/test/Camera/QGCCameraManagerTest.cc
+++ b/test/Camera/QGCCameraManagerTest.cc
@@ -5,6 +5,7 @@
 #include <QtCore/QScopeGuard>
 
 #include "CameraMetaData.h"
+#include "Fixtures/RAIIFixtures.h"
 #include "MAVLinkLib.h"
 #include "QGCCameraManager.h"
 #include "Vehicle.h"
@@ -33,6 +34,7 @@ void QGCCameraManagerTest::_testCameraList()
 /// (CI ASan job). Without ASan the test exercises the path but may pass silently.
 void QGCCameraManagerTest::_testLostCameraCleanupWithPendingRequest()
 {
+    TestFixtures::MavCommandAckTimeoutFixture shortAckTimeout;
     ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
                      QRegularExpression("Giving up sending command after max retries:"));
 

--- a/test/Gimbal/GimbalControllerDiscoveryTest.cc
+++ b/test/Gimbal/GimbalControllerDiscoveryTest.cc
@@ -1,8 +1,11 @@
 #include "GimbalControllerDiscoveryTest.h"
 
+#include <optional>
+
 #include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
 
+#include "Fixtures/RAIIFixtures.h"
 #include "Gimbal.h"
 #include "GimbalController.h"
 #include "MockConfiguration.h"
@@ -148,7 +151,9 @@ void GimbalControllerDiscoveryTest::_testManagerInformationUnavailable()
 {
     QFETCH(MockLinkGimbal::InformationResponse, response);
 
+    std::optional<TestFixtures::MavCommandAckTimeoutFixture> shortAckTimeout;
     if (response == MockLinkGimbal::InformationResponse::Silent) {
+        shortAckTimeout.emplace();
         // Every unanswered request exhausts the command queue's resends
         ignoreLogMessage(
             "Vehicle.MavCommandQueue", QtWarningMsg,
@@ -184,6 +189,7 @@ void GimbalControllerDiscoveryTest::_testManagerInformationUnavailable()
 
 void GimbalControllerDiscoveryTest::_testStatusBeforeInformation()
 {
+    TestFixtures::MavCommandAckTimeoutFixture shortAckTimeout;
     // Unsolicited GIMBAL_MANAGER_STATUS before any GIMBAL_MANAGER_INFORMATION must seed the gimbal, not be dropped,
     // and discovery must still complete once information finally arrives
     ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,

--- a/test/UnitTestFramework/Fixtures/RAIIFixtures.cc
+++ b/test/UnitTestFramework/Fixtures/RAIIFixtures.cc
@@ -6,6 +6,7 @@
 
 #include "AppSettings.h"
 #include "Fact.h"
+#include "MavCommandQueue.h"
 #include "QGCLoggingCategory.h"
 #include "QGCMAVLink.h"
 #include "RunGuard.h"
@@ -287,6 +288,21 @@ QJsonDocument TempJsonFileFixture::readJson(QJsonParseError* error)
     }
 
     return QJsonDocument::fromJson(_file.readAll(), error);
+}
+
+// ============================================================================
+// MavCommandAckTimeoutFixture Implementation
+// ============================================================================
+
+MavCommandAckTimeoutFixture::MavCommandAckTimeoutFixture(int timeoutMs)
+    : _previousOverride(MavCommandQueue::testAckTimeoutOverride())
+{
+    MavCommandQueue::setTestAckTimeoutOverride(timeoutMs);
+}
+
+MavCommandAckTimeoutFixture::~MavCommandAckTimeoutFixture()
+{
+    MavCommandQueue::setTestAckTimeoutOverride(_previousOverride);
 }
 
 // ============================================================================

--- a/test/UnitTestFramework/Fixtures/RAIIFixtures.h
+++ b/test/UnitTestFramework/Fixtures/RAIIFixtures.h
@@ -12,6 +12,7 @@
 #include <QtNetwork/QNetworkReply>
 
 #include <memory>
+#include <optional>
 
 #include "MAVLinkMessageType.h"
 
@@ -227,6 +228,28 @@ private:
     const char* _name;
     QByteArray _value;
     bool _wasSet;
+};
+
+// ============================================================================
+// MavCommandAckTimeoutFixture - short MavCommandQueue ack timeout for timeout-driven tests
+// ============================================================================
+
+/// Shortens the COMMAND_ACK timeout for tests whose outcome depends on at least one ack window
+/// expiring (no ack, or ack only after a retry), so the retry/give-up path doesn't wait the full
+/// production window. Restores the previous override on destruction.
+class MavCommandAckTimeoutFixture
+{
+public:
+    static constexpr int kDefaultTimeoutMs = 500;
+
+    explicit MavCommandAckTimeoutFixture(int timeoutMs = kDefaultTimeoutMs);
+    ~MavCommandAckTimeoutFixture();
+
+    MavCommandAckTimeoutFixture(const MavCommandAckTimeoutFixture&) = delete;
+    MavCommandAckTimeoutFixture& operator=(const MavCommandAckTimeoutFixture&) = delete;
+
+private:
+    std::optional<int> _previousOverride;
 };
 
 // ============================================================================

--- a/test/Utilities/StateMachine/states/RetryableRequestMessageStateTest.cc
+++ b/test/Utilities/StateMachine/states/RetryableRequestMessageStateTest.cc
@@ -2,6 +2,7 @@
 #include "MAVLinkLib.h"
 #include "StateTestCommon.h"
 
+#include "Fixtures/RAIIFixtures.h"
 #include "QGCStateMachine.h"
 #include "MultiVehicleManager.h"
 #include "MockLink.h"
@@ -102,6 +103,7 @@ void RetryableRequestMessageStateTest::_testRetryOnFailure()
 
 void RetryableRequestMessageStateTest::_testMaxRetriesExhausted()
 {
+    TestFixtures::MavCommandAckTimeoutFixture shortAckTimeout;
     // FailRequestMessageCommandNoResponse triggers duplicate-request warnings and retries exhausted.
     ignoreLogMessage("Vehicle.RequestMessageCoordinator", QtWarningMsg,
                      QRegularExpression("failing exact duplicate compId:msgId"));
@@ -150,6 +152,7 @@ void RetryableRequestMessageStateTest::_testMaxRetriesExhausted()
 
 void RetryableRequestMessageStateTest::_testFailOnMaxRetries()
 {
+    TestFixtures::MavCommandAckTimeoutFixture shortAckTimeout;
     // Timeout + no-response mode causes MavCommandQueue and state machine to emit expected warnings.
     ignoreLogMessage("Utilities.StateMachine.RetryableRequestMessageState", QtWarningMsg,
                      QRegularExpression("Max retries exhausted"));

--- a/test/Vehicle/InitialConnectTest.cc
+++ b/test/Vehicle/InitialConnectTest.cc
@@ -1,9 +1,11 @@
 #include "InitialConnectTest.h"
 
 #include <memory>
+#include <optional>
 
 #include <QtTest/QSignalSpy>
 
+#include "Fixtures/RAIIFixtures.h"
 #include "GeoFenceManager.h"
 #include "LinkManager.h"
 #include "MAVLinkProtocol.h"
@@ -321,6 +323,12 @@ void InitialConnectTest::_subsystemFailureFallsThrough()
     QFETCH(bool, blockMissionProtocolImmediately);
     QFETCH(bool, blockMissionProtocolAfterMissionLoad);
     QFETCH(bool, expectParametersReady);
+
+    // Blocked REQUEST_MESSAGE ids are never acked; don't wait the production timeout for them.
+    std::optional<TestFixtures::MavCommandAckTimeoutFixture> shortAckTimeout;
+    if (!blockedMessageIds.isEmpty()) {
+        shortAckTimeout.emplace();
+    }
 
     // Per-row expected noise from the injected subsystem failure.
     if (blockedMessageIds.contains(MAVLINK_MSG_ID_AVAILABLE_MODES) || blockedMessageIds.contains(MAVLINK_MSG_ID_COMPONENT_METADATA)) {

--- a/test/Vehicle/MavCommandQueueReentrancyTest.cc
+++ b/test/Vehicle/MavCommandQueueReentrancyTest.cc
@@ -2,6 +2,7 @@
 
 #include <QtCore/QRegularExpression>
 
+#include "Fixtures/RAIIFixtures.h"
 #include "MultiVehicleManager.h"
 
 void MavCommandQueueReentrancyTest::_closeVehicleResultHandler(void* resultHandlerData, int compId,
@@ -23,6 +24,7 @@ void MavCommandQueueReentrancyTest::_closeVehicleResultHandler(void* resultHandl
 
 void MavCommandQueueReentrancyTest::_testCloseVehicleFromGiveUpHandler()
 {
+    TestFixtures::MavCommandAckTimeoutFixture shortAckTimeout;
     ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
                      QRegularExpression("Giving up sending command after max retries:"));
 

--- a/test/Vehicle/RequestMessageTest.cc
+++ b/test/Vehicle/RequestMessageTest.cc
@@ -1,5 +1,9 @@
 #include "RequestMessageTest.h"
 
+#include <optional>
+
+#include "Fixtures/RAIIFixtures.h"
+#include "MavCommandQueue.h"
 #include "MultiVehicleManager.h"
 
 #include <QtCore/QRegularExpression>
@@ -10,7 +14,7 @@ RequestMessageTest::TestCase_t RequestMessageTest::_rgTestCases[] = {
     {MockLink::FailRequestMessageCommandUnsupported, MAV_RESULT_UNSUPPORTED, Vehicle::RequestMessageFailureCommandError,
      1, MAVLINK_MSG_ID_DEBUG, false, 0},
     {MockLink::FailRequestMessageCommandNoResponse, MAV_RESULT_FAILED, Vehicle::RequestMessageFailureCommandNotAcked,
-     Vehicle::_mavCommandMaxRetryCount, MAVLINK_MSG_ID_DEBUG, false, 0},
+     MavCommandQueue::kMaxRetryCount, MAVLINK_MSG_ID_DEBUG, false, 0, true},
 };
 
 void RequestMessageTest::_requestMessageResultHandler(void* resultHandlerData, MAV_RESULT commandResult,
@@ -29,6 +33,11 @@ void RequestMessageTest::_requestMessageResultHandler(void* resultHandlerData, M
 
 void RequestMessageTest::_testCaseWorker(TestCase_t& testCase)
 {
+    std::optional<TestFixtures::MavCommandAckTimeoutFixture> shortAckTimeout;
+    if (testCase.expectAckTimeout) {
+        shortAckTimeout.emplace();
+    }
+
     MultiVehicleManager* vehicleMgr = MultiVehicleManager::instance();
     Vehicle* vehicle = vehicleMgr->activeVehicle();
     // Gimbal controller sends message requests when receiving heartbeats, trying to find a gimbal, and it messes with

--- a/test/Vehicle/RequestMessageTest.h
+++ b/test/Vehicle/RequestMessageTest.h
@@ -33,6 +33,7 @@ private:
         int expectedMessageId;
         bool resultHandlerCalled;
         int callbackCount;
+        bool expectAckTimeout = false;  ///< Outcome depends on the ack timeout expiring at least once
     };
 
     void _testCaseWorker(TestCase_t& testCase);

--- a/test/Vehicle/SendMavCommandWithHandlerTest.cc
+++ b/test/Vehicle/SendMavCommandWithHandlerTest.cc
@@ -1,5 +1,9 @@
 #include "SendMavCommandWithHandlerTest.h"
 
+#include <optional>
+
+#include "Fixtures/RAIIFixtures.h"
+#include "MavCommandQueue.h"
 #include "MultiVehicleManager.h"
 
 #include <QtCore/QRegularExpression>
@@ -10,19 +14,19 @@ SendMavCommandWithHandlerTest::TestCase_t SendMavCommandWithHandlerTest::_rgTest
     {MockLink::MAV_CMD_MOCKLINK_ALWAYS_RESULT_FAILED, MAV_RESULT_FAILED, false, Vehicle::MavCmdResultCommandResultOnly,
      1},
     {MockLink::MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_ACCEPTED, MAV_RESULT_ACCEPTED, false,
-     Vehicle::MavCmdResultCommandResultOnly, 2},
+     Vehicle::MavCmdResultCommandResultOnly, 2, true},
     {MockLink::MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_FAILED, MAV_RESULT_FAILED, false,
-     Vehicle::MavCmdResultCommandResultOnly, 2},
+     Vehicle::MavCmdResultCommandResultOnly, 2, true},
     {MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE, MAV_RESULT_FAILED, false, Vehicle::MavCmdResultFailureNoResponseToCommand,
-     Vehicle::_mavCommandMaxRetryCount},
+     MavCommandQueue::kMaxRetryCount, true},
     {MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE_NO_RETRY, MAV_RESULT_FAILED, false,
-     Vehicle::MavCmdResultFailureNoResponseToCommand, 1},
+     Vehicle::MavCmdResultFailureNoResponseToCommand, 1, true},
     {MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_ACCEPTED, MAV_RESULT_ACCEPTED, true,
      Vehicle::MavCmdResultCommandResultOnly, 1},
     {MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_FAILED, MAV_RESULT_FAILED, true,
      Vehicle::MavCmdResultCommandResultOnly, 1},
     {MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_NO_ACK, MAV_RESULT_FAILED, true,
-     Vehicle::MavCmdResultFailureNoResponseToCommand, 1},
+     Vehicle::MavCmdResultFailureNoResponseToCommand, 1, true},
 };
 bool SendMavCommandWithHandlerTest::_resultHandlerCalled = false;
 bool SendMavCommandWithHandlerTest::_progressHandlerCalled = false;
@@ -54,6 +58,11 @@ void SendMavCommandWithHandlerTest::_mavCmdProgressHandler(void* progressHandler
 
 void SendMavCommandWithHandlerTest::_testCaseWorker(TestCase_t& testCase)
 {
+    std::optional<TestFixtures::MavCommandAckTimeoutFixture> shortAckTimeout;
+    if (testCase.expectAckTimeout) {
+        shortAckTimeout.emplace();
+    }
+
     MultiVehicleManager* vehicleMgr = MultiVehicleManager::instance();
     Vehicle* vehicle = vehicleMgr->activeVehicle();
     Vehicle::MavCmdAckHandlerInfo_t handlerInfo = {};

--- a/test/Vehicle/SendMavCommandWithHandlerTest.h
+++ b/test/Vehicle/SendMavCommandWithHandlerTest.h
@@ -27,6 +27,7 @@ private:
         bool expectInProgressResult;
         Vehicle::MavCmdResultFailureCode_t expectedFailureCode;
         int expectedSendCount;
+        bool expectAckTimeout = false;  ///< Outcome depends on the ack timeout expiring at least once
     };
 
     void _testCaseWorker(TestCase_t& testCase);

--- a/test/Vehicle/SendMavCommandWithSignallingTest.cc
+++ b/test/Vehicle/SendMavCommandWithSignallingTest.cc
@@ -1,9 +1,13 @@
 #include "SendMavCommandWithSignallingTest.h"
 
+#include <optional>
+
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QRegularExpression>
 #include <QtTest/QSignalSpy>
 
+#include "Fixtures/RAIIFixtures.h"
+#include "MavCommandQueue.h"
 #include "MultiVehicleManager.h"
 
 namespace {
@@ -38,23 +42,28 @@ SendMavCommandWithSignallingTest::TestCase_t SendMavCommandWithSignallingTest::_
     {MockLink::MAV_CMD_MOCKLINK_ALWAYS_RESULT_ACCEPTED, MAV_RESULT_ACCEPTED, Vehicle::MavCmdResultCommandResultOnly, 1},
     {MockLink::MAV_CMD_MOCKLINK_ALWAYS_RESULT_FAILED, MAV_RESULT_FAILED, Vehicle::MavCmdResultCommandResultOnly, 1},
     {MockLink::MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_ACCEPTED, MAV_RESULT_ACCEPTED,
-     Vehicle::MavCmdResultCommandResultOnly, 2},
+     Vehicle::MavCmdResultCommandResultOnly, 2, true},
     {MockLink::MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_FAILED, MAV_RESULT_FAILED, Vehicle::MavCmdResultCommandResultOnly,
-     2},
+     2, true},
     {MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE, MAV_RESULT_FAILED, Vehicle::MavCmdResultFailureNoResponseToCommand,
-     Vehicle::_mavCommandMaxRetryCount},
+     MavCommandQueue::kMaxRetryCount, true},
     {MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE_NO_RETRY, MAV_RESULT_FAILED,
-     Vehicle::MavCmdResultFailureNoResponseToCommand, 1},
+     Vehicle::MavCmdResultFailureNoResponseToCommand, 1, true},
     {MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_ACCEPTED, MAV_RESULT_ACCEPTED,
      Vehicle::MavCmdResultCommandResultOnly, 1},
     {MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_FAILED, MAV_RESULT_FAILED, Vehicle::MavCmdResultCommandResultOnly,
      1},
     {MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_NO_ACK, MAV_RESULT_FAILED,
-     Vehicle::MavCmdResultFailureNoResponseToCommand, 1},
+     Vehicle::MavCmdResultFailureNoResponseToCommand, 1, true},
 };
 
 void SendMavCommandWithSignallingTest::_testCaseWorker(TestCase_t& testCase)
 {
+    std::optional<TestFixtures::MavCommandAckTimeoutFixture> shortAckTimeout;
+    if (testCase.expectAckTimeout) {
+        shortAckTimeout.emplace();
+    }
+
     MultiVehicleManager* vehicleMgr = MultiVehicleManager::instance();
     Vehicle* vehicle = vehicleMgr->activeVehicle();
     QSignalSpy spyResult(vehicle, &Vehicle::mavCommandResult);

--- a/test/Vehicle/SendMavCommandWithSignallingTest.h
+++ b/test/Vehicle/SendMavCommandWithSignallingTest.h
@@ -25,6 +25,7 @@ private:
         MAV_RESULT expectedCommandResult;
         Vehicle::MavCmdResultFailureCode_t expectedFailureCode;
         int expectedSendCount;
+        bool expectAckTimeout = false;  ///< Outcome depends on the ack timeout expiring at least once
     };
 
     void _testCaseWorker(TestCase_t& testCase);


### PR DESCRIPTION
Fixes #15095

## Problem

`MavCommandQueue` shortened the COMMAND_ACK timeout to 500 ms for **every** unit test via a global `kTestAckTimeoutMs`. That knob conflated two different situations:

- **Ack is expected** — the timeout should never be what ends the wait, so shortening it buys nothing and only adds a failure mode production doesn't have. Under an instrumented coverage build the main thread can be busy for >500 ms between `sendMavCommand()` and processing MockLink's queued ack (MockLink lives on the main thread; the ack needs one more event-loop pass). `SET_MESSAGE_INTERVAL` is sent from `APMFirmwarePlugin::initializeVehicle()` inside the `Vehicle` constructor and is single-try, so it was given up on before its ack was processed → strict-mode failure in `APMFreshFlashUITest`.
- **Ack is deliberately never sent** — the timeout *is* the thing being waited on, so shortening it is pure speedup.

## Change

- `MavCommandQueue::_ackTimeoutMSecs()` now returns the production 1200 ms unless a test override is set (`setTestAckTimeoutOverride`). The setter is guarded to unit-test runs and rejects non-positive values.
- New `TestFixtures::MavCommandAckTimeoutFixture` (RAII, saves/restores the previous override) for tests whose outcome depends on the ack timeout expiring.
- Applied only where needed: `SendMavCommandWithHandlerTest`, `SendMavCommandWithSignallingTest`, `RequestMessageTest` (per-row via a new `expectAckTimeout` flag so acked rows run at 1200 ms), `RetryableRequestMessageStateTest`, `MavCommandQueueReentrancyTest`, `QGCCameraManagerTest`, and `InitialConnectTest` blocked-message rows.
- Removed the dead `kTest*` constants on `MavCommandQueue` / `Vehicle` and the duplicated `Vehicle::_mavCommandMaxRetryCount`; tests reference `MavCommandQueue::kMaxRetryCount` directly.

## Testing

All touched tests pass locally (macOS Debug): `APMFreshFlashUITest`, `InitialConnectTest`, `VehicleLinkManagerTest`, `RequestMessageTest`, `SendMavCommandWithHandlerTest`, `SendMavCommandWithSignallingTest`, `RetryableRequestMessageStateTest`, `MavCommandQueueReentrancyTest`, `QGCCameraManagerTest`. No measurable change in test runtime.
